### PR TITLE
Fix clippy warnings in 1.54

### DIFF
--- a/crd/src/error.rs
+++ b/crd/src/error.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Pod has no hostname assignment, this is most probably a transient failure and should be retried: [{pod}]")]

--- a/crd/src/util.rs
+++ b/crd/src/util.rs
@@ -555,7 +555,7 @@ mod tests {
         let conn_string = get_opa_connection_string_from_pods(
             &opa_spec,
             &pods,
-            &opa_api,
+            opa_api,
             opa_api_protocol,
             desired_node_name,
         )

--- a/crd/src/util.rs
+++ b/crd/src/util.rs
@@ -303,12 +303,12 @@ fn get_opa_connection_string_from_pods(
             Some(role_group) => role_group.to_owned(),
         };
 
-        let opa_port = get_opa_port(&opa_spec, &role_group)?;
+        let opa_port = get_opa_port(opa_spec, &role_group)?;
 
         // if a node_name is provided we prefer OPA deployments that are located on the same machine
         if let Some(desired_host) = &desired_node_name {
             if node_name == desired_host {
-                let url = opa_api.get_url(opa_api_protocol, &node_name, opa_port)?;
+                let url = opa_api.get_url(opa_api_protocol, node_name, opa_port)?;
                 debug!(
                     "Found Opa deployment on provided node [{}]; Using this one [{}] ...",
                     node_name, url
@@ -329,7 +329,7 @@ fn get_opa_connection_string_from_pods(
     let server = server_and_port_list.choose(&mut rand::thread_rng());
 
     if let Some(server_url) = server {
-        Ok(opa_api.get_url(opa_api_protocol, &server_url.0, server_url.1)?)
+        Ok(opa_api.get_url(opa_api_protocol, server_url.0, server_url.1)?)
     } else {
         Err(OpaServerMissing)
     }

--- a/operator/src/error.rs
+++ b/operator/src/error.rs
@@ -1,5 +1,6 @@
 use std::num::ParseIntError;
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     // TODO: move to operator-rs

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -180,7 +180,7 @@ impl OpaState {
                             .create_pod_and_config_maps(
                                 &role,
                                 role_group,
-                                &node_name,
+                                node_name,
                                 config_for_role_and_group(
                                     role_str,
                                     role_group,
@@ -370,7 +370,7 @@ impl ReconciliationState for OpaState {
                 .await?
                 .then(
                     self.context
-                        .wait_for_running_and_ready_pods(&self.existing_pods.as_slice()),
+                        .wait_for_running_and_ready_pods(self.existing_pods.as_slice()),
                 )
                 .await?
                 .then(self.context.delete_excess_pods(
@@ -459,7 +459,7 @@ pub fn validated_product_config(
     validate_all_roles_and_groups_config(
         &resource.spec.version.to_string(),
         &role_config,
-        &product_config,
+        product_config,
         false,
         false,
     )


### PR DESCRIPTION
## Description

Rust 1.54 introduced some new Clippy warnings. This PR fixes all of those
