### PR TITLE
Adapted to operator-rs build_resource_name and create_config_map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.1.0-nightly"
-source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#ed04ff725de4167ca70857431eded3209d9caf20"
+source = "git+https://github.com/stackabletech/operator-rs.git?branch=add_create_config_maps_with_labels#f15c45e7fda1851b46231df7246ad303eacdaefc"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1652,6 +1652,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "strum",
+ "strum_macros",
  "thiserror",
  "tokio",
  "tracing",

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -7,7 +7,7 @@ name = "stackable-opa-crd"
 version = "0.1.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "add_create_config_maps_with_labels" }
 
 k8s-openapi = { version = "0.12.0", default-features = false }
 kube = { version = "0.58", default-features = false, features = ["derive"] }

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0-nightly"
 [dependencies]
 product-config = { git = "https://github.com/stackabletech/product-config.git", branch = "main" }
 stackable-opa-crd = { path = "../crd" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "add_create_config_maps_with_labels" }
 
 async-trait = "0.1"
 futures = "0.3"

--- a/operator/src/error.rs
+++ b/operator/src/error.rs
@@ -3,9 +3,16 @@ use std::num::ParseIntError;
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    // TODO: move to operator-rs
-    #[error("Invalid Configmap. No name found which is required to query the ConfigMap.")]
-    InvalidConfigMap,
+    #[error(
+        "ConfigMap of type [{cm_type}] is for pod with generate_name [{pod_name}] is missing."
+    )]
+    MissingConfigMapError {
+        cm_type: &'static str,
+        pod_name: String,
+    },
+
+    #[error("ConfigMap of type [{cm_type}] is missing the metadata.name. Maybe the config map was not created yet?")]
+    MissingConfigMapNameError { cm_type: &'static str },
 
     #[error("Kubernetes reported error: {source}")]
     KubeError {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,7 +9,7 @@ build = "build.rs"
 
 [dependencies]
 stackable_config = { git = "https://github.com/stackabletech/common.git", branch = "main" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "add_create_config_maps_with_labels" }
 stackable-opa-crd = { path = "../crd" }
 stackable-opa-operator = { path = "../operator" }
 
@@ -21,7 +21,7 @@ tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "add_create_config_maps_with_labels" }
 stackable-opa-crd = { path = "../crd" }
 
 [package.metadata.deb]


### PR DESCRIPTION
## Description

- Split create_pod_and_config_maps into create_pod and create_config_maps
- Using operator-rs build_config_map and create_config_map
- Using operator-rs build_resource_name for pods and config maps.

Related: [10](https://github.com/stackabletech/issues/issues/10)

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
