### PR TITLE
Fixes OPA cluster exists but no pods are found empty connect string is returned

### DIFF
--- a/crd/src/error.rs
+++ b/crd/src/error.rs
@@ -10,6 +10,9 @@ pub enum Error {
     #[error("Did not find any suitable OPA server. Please confirm that at least one OPA pod is up and running.")]
     OpaServerMissing,
 
+    #[error("No pods are found for OPA cluster [{namespace}/{name}]. Please check the OPA custom resource and OPA Operator for errors.")]
+    NoOpaPodsAvailableForConnectionInfo { namespace: String, name: String },
+
     #[error("Kubernetes reported error: {source}")]
     KubeError {
         #[from]


### PR DESCRIPTION
## Description
If a zookeeper cluster exists and is found but no pods are found we throw an error because no connect string can be build.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
