### PR TITLE
Correction to stackable-opa-operator-server package name

### DIFF
--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -36,7 +36,7 @@ After you added the repository run:
 [source,bash]
 ----
 sudo apt-get update
-sudo apt-get install stackable-opa-operator
+sudo apt-get install stackable-opa-operator-server
 ----
 
 === RHEL/CentOS
@@ -76,7 +76,7 @@ Install the Operator:
 
 [source,bash]
 ----
-sudo yum install stackable-opa-operator
+sudo yum install stackable-opa-operator-server
 ----
 
 == Docker


### PR DESCRIPTION
According to https://repo.stackable.tech/#browse/browse:deb-dev:packages and https://repo.stackable.tech/#browse/browse:rpm-dev:el8 the package is named with `-server`

## Description

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
