### PR TITLE
[Merged by Bors] - Document service discovery

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,3 +2,5 @@
 * xref:usage.adoc[]
 * xref:configuration.adoc[]
 * xref:implementation-notes.adoc[]
+* Concepts
+** xref:discovery.adoc[]

--- a/docs/modules/ROOT/pages/discovery.adoc
+++ b/docs/modules/ROOT/pages/discovery.adoc
@@ -1,0 +1,51 @@
+:clusterName: simple-opa
+:namespace: stackable
+:packageName: opa-test
+:policyName: allow
+
+= Discovery Profiles
+
+The Stackable Operator for OpenPolicyAgent (OPA) creates a single discovery profile that allows access to the OPA cluster which is published into the Kubernetes cluster as a
+https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmap-v1-core[`ConfigMap`] object.
+
+== Profiles
+
+=== Default
+
+This profile allows access to the OPA cluster from inside the Kubernetes cluster, and connects directly to the NodePort `Service`.
+
+We ensure local access via an https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/[`InternalTrafficPolicy`]. This means that https://kubernetes.io/docs/concepts/workloads/pods/[`Pods`] accessing OPA via the service discovery will be routed to the OPA `Pod` on the same https://kubernetes.io/docs/concepts/architecture/nodes/[`Node`] to reduce request latency. This feature is only activated per default in Kubernetes versions https://github.com/kubernetes/kubernetes/pull/103462[`1.22`] or higher.
+
+== Contents
+
+Given the following OPA cluster:
+[subs="attributes"]
+----
+apiVersion: opa.stackable.tech/v1alpha1
+kind: OpaCluster
+metadata:
+  name: {clusterName} # <1>
+  namespace: {namespace} # <2>
+spec:
+  version:
+  servers:
+    roleGroups:
+      default:
+        selector:
+          matchLabels:
+            kubernetes.io/os: linux
+----
+<1> Name of the OPA cluster which is the name of the `ConfigMap` created for this discovery profile.
+<2> Namespace of the `ConfigMap` created for this discovery profile.
+
+The discovery profile contains the following field:
+
+`OPA`:: A connection string for cluster internal OPA requests. Provided the cluster example above, the connection string is created as follows: http://{clusterName}.{namespace}.svc.cluster.local:8081/ where
+`{clusterName}` represents the name and `{namespace}` the namespace of the cluster.
+
+This connection string points to the base URL (and web UI) of the OPA cluster. In order to query policies you have to configure your product and its OPA url as follows, given the rego package name `{packageName}` and the policy name `{policyName}`:
+
+[subs="attributes"]
+----
+http://{clusterName}.{namespace}.svc.cluster.local:8081/v1/data/{packageName}/{policyName}
+----

--- a/docs/modules/ROOT/pages/discovery.adoc
+++ b/docs/modules/ROOT/pages/discovery.adoc
@@ -10,14 +10,6 @@ https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmap-v
 
 == Profiles
 
-=== Default
-
-This profile allows access to the OPA cluster from inside the Kubernetes cluster, and connects directly to the NodePort `Service`.
-
-We ensure local access via an https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/[`InternalTrafficPolicy`]. This means that https://kubernetes.io/docs/concepts/workloads/pods/[`Pods`] accessing OPA via the service discovery will be routed to the OPA `Pod` on the same https://kubernetes.io/docs/concepts/architecture/nodes/[`Node`] to reduce request latency. This feature is only activated per default in Kubernetes versions https://github.com/kubernetes/kubernetes/pull/103462[`1.22`] or higher.
-
-== Contents
-
 Given the following OPA cluster:
 [subs="attributes"]
 ----
@@ -27,16 +19,20 @@ metadata:
   name: {clusterName} # <1>
   namespace: {namespace} # <2>
 spec:
-  version:
-  servers:
-    roleGroups:
-      default:
-        selector:
-          matchLabels:
-            kubernetes.io/os: linux
+  [...]
 ----
 <1> Name of the OPA cluster which is the name of the `ConfigMap` created for this discovery profile.
 <2> Namespace of the `ConfigMap` created for this discovery profile.
+
+The published `ConfigMap` name and namespace are equal to the cluster name and namespace. In this case `{namespace}/{clusterName}`.
+
+=== Default
+
+This profile allows access to the OPA cluster from inside the Kubernetes cluster, and connects directly to the NodePort `Service`.
+
+We ensure local access via an https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/[`InternalTrafficPolicy`]. This means that https://kubernetes.io/docs/concepts/workloads/pods/[`Pods`] accessing OPA via the service discovery will be routed to the OPA `Pod` on the same https://kubernetes.io/docs/concepts/architecture/nodes/[`Node`] to reduce request latency. This feature is only activated per default in Kubernetes versions https://github.com/kubernetes/kubernetes/pull/103462[`1.22`] or higher.
+
+== Contents
 
 The discovery profile contains the following field:
 

--- a/docs/modules/ROOT/pages/discovery.adoc
+++ b/docs/modules/ROOT/pages/discovery.adoc
@@ -28,8 +28,6 @@ spec:
 
 The resulting discovery `ConfigMap` is `{namespace}/{clusterName}`.
 
-We ensure local access via an https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/[`InternalTrafficPolicy`]. This means that https://kubernetes.io/docs/concepts/workloads/pods/[`Pods`] accessing OPA via the service discovery will be routed to the OPA `Pod` on the same https://kubernetes.io/docs/concepts/architecture/nodes/[`Node`] to reduce request latency. This feature is only activated per default in Kubernetes versions https://github.com/kubernetes/kubernetes/pull/103462[`1.22`] or higher.
-
 == Contents
 
 The `{namespace}/{clusterName}` discovery `ConfigMap` contains the following fields where `{clusterName}` represents the name and `{namespace}` the namespace of the cluster:

--- a/docs/modules/ROOT/pages/discovery.adoc
+++ b/docs/modules/ROOT/pages/discovery.adoc
@@ -34,14 +34,17 @@ We ensure local access via an https://kubernetes.io/docs/concepts/services-netwo
 
 == Contents
 
-The discovery profile contains the following field:
+The discovery profile contains the following fields where `{clusterName}` represents the name and `{namespace}` the namespace of the cluster:
 
-`OPA`:: A connection string for cluster internal OPA requests. Provided the cluster example above, the connection string is created as follows: http://{clusterName}.{namespace}.svc.cluster.local:8081/ where
-`{clusterName}` represents the name and `{namespace}` the namespace of the cluster.
+`OPA`::
+====
+A connection string for cluster internal OPA requests. Provided the cluster example above, the connection string is created as follows:
+
+[subs="attributes"]
+    http://{clusterName}.{namespace}.svc.cluster.local:8081/
 
 This connection string points to the base URL (and web UI) of the OPA cluster. In order to query policies you have to configure your product and its OPA url as follows, given the rego package name `{packageName}` and the policy name `{policyName}`:
 
 [subs="attributes"]
-----
-http://{clusterName}.{namespace}.svc.cluster.local:8081/v1/data/{packageName}/{policyName}
-----
+    http://{clusterName}.{namespace}.svc.cluster.local:8081/v1/data/{packageName}/{policyName}
+====

--- a/docs/modules/ROOT/pages/discovery.adoc
+++ b/docs/modules/ROOT/pages/discovery.adoc
@@ -3,15 +3,17 @@
 :packageName: opa-test
 :policyName: allow
 
-= Discovery Profiles
+= Discovery
 
-The Stackable Operator for OpenPolicyAgent (OPA) creates a single discovery profile that allows access to the OPA cluster which is published into the Kubernetes cluster as a
-https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmap-v1-core[`ConfigMap`] object.
+The Stackable Operator for OpenPolicyAgent (OPA) publishes a discovery https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmap-v1-core[`ConfigMap`], which exposes a client configuration bundle that allows access to the OPA cluster.
 
-== Profiles
+The bundle includes a connection string to access the OPA cluster. This string may be used by other operators or tools to configure their products with access to OPA. This is limited to internal cluster access.
+
+== Example
 
 Given the following OPA cluster:
-[subs="attributes"]
+
+[source,yaml,subs="normal,callouts"]
 ----
 apiVersion: opa.stackable.tech/v1alpha1
 kind: OpaCluster
@@ -21,20 +23,16 @@ metadata:
 spec:
   [...]
 ----
-<1> Name of the OPA cluster which is the name of the `ConfigMap` created for this discovery profile.
-<2> Namespace of the `ConfigMap` created for this discovery profile.
+<1> The name of the OPA cluster, which is also the name of the created discovery `ConfigMap`.
+<2> The namespace of the discovery `ConfigMap`.
 
-The published `ConfigMap` name and namespace are equal to the cluster name and namespace. In this case `{namespace}/{clusterName}`.
-
-=== Default
-
-This profile allows access to the OPA cluster from inside the Kubernetes cluster, and connects directly to the NodePort `Service`.
+The resulting discovery `ConfigMap` is `{namespace}/{clusterName}`.
 
 We ensure local access via an https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/[`InternalTrafficPolicy`]. This means that https://kubernetes.io/docs/concepts/workloads/pods/[`Pods`] accessing OPA via the service discovery will be routed to the OPA `Pod` on the same https://kubernetes.io/docs/concepts/architecture/nodes/[`Node`] to reduce request latency. This feature is only activated per default in Kubernetes versions https://github.com/kubernetes/kubernetes/pull/103462[`1.22`] or higher.
 
 == Contents
 
-The discovery profile contains the following fields where `{clusterName}` represents the name and `{namespace}` the namespace of the cluster:
+The `{namespace}/{clusterName}` discovery `ConfigMap` contains the following fields where `{clusterName}` represents the name and `{namespace}` the namespace of the cluster:
 
 `OPA`::
 ====

--- a/docs/modules/ROOT/pages/implementation-notes.adoc
+++ b/docs/modules/ROOT/pages/implementation-notes.adoc
@@ -8,6 +8,8 @@ but should not be required reading for regular use.
 We run an OPA on each node, because we want to avoid requiring network round trips for services making
 policy queries (which are often chained in serial, and block other tasks in the products).
 
+We ensure local access via an https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/[`InternalTrafficPolicy`]. This means that https://kubernetes.io/docs/concepts/workloads/pods/[`Pods`] accessing OPA via the service discovery will be routed to the OPA `Pod` on the same https://kubernetes.io/docs/concepts/architecture/nodes/[`Node`] to reduce request latency and network traffic. This feature is only activated per default in Kubernetes versions https://github.com/kubernetes/kubernetes/pull/103462[`1.22`] or higher.
+
 == OPA Bundle Builder
 
 Each OPA pod runs a container that watches for `ConfigMap` objects labeled `opa.stackable.tech/bundle`.

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -296,6 +296,7 @@ pub fn build_server_role_service(opa: &OpaCluster) -> Result<Service> {
             }]),
             selector: Some(role_selector_labels(opa, APP_NAME, &role_name)),
             type_: Some("NodePort".to_string()),
+            internal_traffic_policy: Some("Local".to_string()),
             ..ServiceSpec::default()
         }),
         status: None,


### PR DESCRIPTION
## Description

- added service discovery docs
- added `internal_traffic_policy` = `Local` to NodePort service (works for Kubernetes v1.22 and above)

closes https://github.com/stackabletech/opa-operator/issues/236

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
