### PR TITLE
[Merged by Bors] - moved CI tests to operator repo

### DIFF
--- a/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: hcloud-centos-8
+metadata:
+  name: opa-operator-integration-tests
+  description: "Cluster for Opa Operator Integration Tests (Hetzner Cloud / CentOS 8)"
+domain: stackable.test
+publicKeys: []
+spec:
+  location: "hel1"
+  k8sVersion: "$K8S_VERSION"
+  wireguard: false
+  versions:
+    _-operator: NIGHTLY
+    opa-operator: "$OPA_OPERATOR_VERSION"
+  nodes:
+    main:
+      numberOfNodes: 3

--- a/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+git clone -b "$GIT_BRANCH" https://github.com/stackabletech/opa-operator.git
+(cd opa-operator/ && ./scripts/run_tests.sh)
+exit_code=$?
+./operator-logs.sh opa > /target/opa-operator.log
+./operator-logs.sh regorule > /target/regorule-operator.log
+exit $exit_code


### PR DESCRIPTION
## Description

moved CI tests to operator source repository

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

test run: https://ci.stackable.tech/job/OPA%20Operator%20Integration%20Tests%20(flex)/35/


## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
