### PR TITLE
[Merged by Bors] - Updated code to adhere to ADR018 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - `operator-rs` `0.10.0` -> `0.15.0` ([#241], [#244], [#273]).
 - BREAKING: Renamed custom resource from `OpenPolicyAgent` to `OpaCluster` ([#244]).
 - Replace the `tempdir` crate with `tempfile` ([#287]).
+- [BREAKING] Specifying the product version has been changed to adhere to [ADR018](https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html) instead of just specifying the product version you will now have to add the Stackable image version as well, so `version: 3.5.8` becomes (for example) `version: 3.5.8-stackable0.1.0` ([#xxx])
 
 ### Removed
 
@@ -33,6 +34,7 @@ All notable changes to this project will be documented in this file.
 [#273]: https://github.com/stackabletech/opa-operator/pull/273
 [#287]: https://github.com/stackabletech/opa-operator/pull/287
 [#289]: https://github.com/stackabletech/opa-operator/pull/289
+[#xxx]: https://github.com/stackabletech/opa-operator/pull/xxx
 
 ## [0.8.0] - 2022-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
 - `operator-rs` `0.10.0` -> `0.15.0` ([#241], [#244], [#273]).
 - BREAKING: Renamed custom resource from `OpenPolicyAgent` to `OpaCluster` ([#244]).
 - Replace the `tempdir` crate with `tempfile` ([#287]).
-- [BREAKING] Specifying the product version has been changed to adhere to [ADR018](https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html) instead of just specifying the product version you will now have to add the Stackable image version as well, so `version: 3.5.8` becomes (for example) `version: 3.5.8-stackable0.1.0` ([#xxx])
+- [BREAKING] Specifying the product version has been changed to adhere to [ADR018](https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html) instead of just specifying the product version you will now have to add the Stackable image version as well, so `version: 3.5.8` becomes (for example) `version: 3.5.8-stackable0.1.0` ([#293])
 
 ### Removed
 
@@ -34,7 +34,7 @@ All notable changes to this project will be documented in this file.
 [#273]: https://github.com/stackabletech/opa-operator/pull/273
 [#287]: https://github.com/stackabletech/opa-operator/pull/287
 [#289]: https://github.com/stackabletech/opa-operator/pull/289
-[#xxx]: https://github.com/stackabletech/opa-operator/pull/xxx
+[#293]: https://github.com/stackabletech/opa-operator/pull/293
 
 ## [0.8.0] - 2022-02-14
 

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -16,7 +16,7 @@ To create a single node OPA (v0.37.2) cluster with Prometheus metrics exposed on
     metadata:
       name: simple-opa
     spec:
-      version: "0.37.2"
+      version: "0.37.2-stackable0.2.0"
       servers:
         roleGroups:
           default:
@@ -24,6 +24,11 @@ To create a single node OPA (v0.37.2) cluster with Prometheus metrics exposed on
               matchLabels:
                 kubernetes.io/os: linux
 ----
+
+Please note that the version you need to specify is not only the version of OPA which you want to roll out, but has to be amended with a Stackable version as shown.
+This Stackable version is the version of the underlying container image which is used to execute the processes.
+For a list of available versions please check our https://repo.stackable.tech/#browse/browse:docker:v2%2Fstackable%2Fdruid%2Ftags[image registry].
+It should generally be safe to simply use the latest image version that is available.
 
 == Bundle Sources
 

--- a/examples/simple-opa-cluster.yaml
+++ b/examples/simple-opa-cluster.yaml
@@ -4,7 +4,7 @@ kind: OpaCluster
 metadata:
   name: simple-opa
 spec:
-  version: "0.37.2"
+  version: "0.37.2-stackable0.2.0"
   servers:
     roleGroups:
       default:

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -381,7 +381,7 @@ fn build_server_rolegroup_daemonset(
 ) -> Result<DaemonSet> {
     let opa_version = opa_version(opa)?;
     let image = format!(
-        "docker.stackable.tech/stackable/opa:{}-stackable0",
+        "docker.stackable.tech/stackable/opa:{}",
         opa_version
     );
     let sa_name = format!(

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -380,10 +380,7 @@ fn build_server_rolegroup_daemonset(
     server_config: &HashMap<PropertyNameKind, BTreeMap<String, String>>,
 ) -> Result<DaemonSet> {
     let opa_version = opa_version(opa)?;
-    let image = format!(
-        "docker.stackable.tech/stackable/opa:{}",
-        opa_version
-    );
+    let image = format!("docker.stackable.tech/stackable/opa:{}", opa_version);
     let sa_name = format!(
         "{}-{}",
         opa.metadata.name.as_ref().unwrap(),

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,7 +2,7 @@
 dimensions:
   - name: opa
     values:
-      - 0.37.2
+      - 0.37.2-stackable0.2.0
 tests:
   - name: smoke
     dimensions:


### PR DESCRIPTION
# Description
Updated code to adhere to ADR018 
This contains a breaking change, since the version that is specified for OPA now has to include a stackable image version.

Previously the version could be specified as "version: 3.2.1" and the operator simply added the stackable version to this. But going forward we have decided that the image version has to be explictly specified, so it will now have to be "version: 3.2.1-stackable-0.1.0" or similar.

This is in accordance with ADR18 (https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html).

*Please add a description here. This will become the commit message of the merge request later.*

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
