### PR TITLE
[Merged by Bors] - Actually removed decision logs

### DIFF
--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -717,9 +717,6 @@ bundles:
     polling:
       min_delay_seconds: 10
       max_delay_seconds: 20
-
-decision_logs:
-    console: true
 "
 }
 


### PR DESCRIPTION
# Description

Actually did not remove the decision log config in https://github.com/stackabletech/opa-operator/pull/423

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
