### PR TITLE
fix: forward the correct log level to log processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,8 +2397,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.69.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.0#9ff61fa29c30b5aedc5c11b929079477e2642a7a"
+version = "0.69.1"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.1#3e543e6a3783c025956f348d86cd5369a132e52f"
 dependencies = [
  "chrono",
  "clap",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.0#9ff61fa29c30b5aedc5c11b929079477e2642a7a"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.1#3e543e6a3783c025956f348d86cd5369a132e52f"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,8 +2397,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.69.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.1#3e543e6a3783c025956f348d86cd5369a132e52f"
+version = "0.69.2"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.2#9dcd255edee85e24c6a131ad4d61b17654ddf7c9"
 dependencies = [
  "chrono",
  "clap",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.1#3e543e6a3783c025956f348d86cd5369a132e52f"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.2#9dcd255edee85e24c6a131ad4d61b17654ddf7c9"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -1881,102 +1881,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "std" ];
       };
-      "event-listener 4.0.3" = rec {
-        crateName = "event-listener";
-        version = "4.0.3";
-        edition = "2021";
-        sha256 = "0vk4smw1vf871vi76af1zn7w69jg3zmpjddpby2qq91bkg21bck7";
-        authors = [
-          "Stjepan Glavina <stjepang@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "concurrent-queue";
-            packageId = "concurrent-queue";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "parking";
-            packageId = "parking";
-            optional = true;
-            target = { target, features }: (!(builtins.elem "wasm" target."family"));
-          }
-          {
-            name = "pin-project-lite";
-            packageId = "pin-project-lite";
-          }
-        ];
-        features = {
-          "default" = [ "std" ];
-          "parking" = [ "dep:parking" ];
-          "portable-atomic" = [ "portable-atomic-util" "portable_atomic_crate" ];
-          "portable-atomic-util" = [ "dep:portable-atomic-util" ];
-          "portable_atomic_crate" = [ "dep:portable_atomic_crate" ];
-          "std" = [ "concurrent-queue/std" "parking" ];
-        };
-        resolvedDefaultFeatures = [ "parking" "std" ];
-      };
-      "event-listener 5.3.0" = rec {
-        crateName = "event-listener";
-        version = "5.3.0";
-        edition = "2021";
-        sha256 = "091a6bgxzjnycqa10l2sqwzzy0j9vpw7a1w0nbglqlqkraw496bd";
-        authors = [
-          "Stjepan Glavina <stjepang@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "concurrent-queue";
-            packageId = "concurrent-queue";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "parking";
-            packageId = "parking";
-            optional = true;
-            target = { target, features }: (!(builtins.elem "wasm" target."family"));
-          }
-          {
-            name = "pin-project-lite";
-            packageId = "pin-project-lite";
-          }
-        ];
-        features = {
-          "default" = [ "std" ];
-          "loom" = [ "concurrent-queue/loom" "parking?/loom" "dep:loom" ];
-          "parking" = [ "dep:parking" ];
-          "portable-atomic" = [ "portable-atomic-util" "portable_atomic_crate" ];
-          "portable-atomic-util" = [ "dep:portable-atomic-util" ];
-          "portable_atomic_crate" = [ "dep:portable_atomic_crate" ];
-          "std" = [ "concurrent-queue/std" "parking" ];
-        };
-        resolvedDefaultFeatures = [ "default" "parking" "std" ];
-      };
-      "event-listener-strategy 0.4.0" = rec {
-        crateName = "event-listener-strategy";
-        version = "0.4.0";
-        edition = "2018";
-        sha256 = "1lwprdjqp2ibbxhgm9khw7s7y7k4xiqj5i5yprqiks6mnrq4v3lm";
-        authors = [
-          "John Nunley <dev@notgull.net>"
-        ];
-        dependencies = [
-          {
-            name = "event-listener";
-            packageId = "event-listener 4.0.3";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "pin-project-lite";
-            packageId = "pin-project-lite";
-          }
-        ];
-        features = {
-          "default" = [ "std" ];
-          "std" = [ "event-listener/std" ];
-        };
-        resolvedDefaultFeatures = [ "std" ];
-      };
       "event-listener" = rec {
         crateName = "event-listener";
         version = "5.3.1";
@@ -3150,98 +3054,6 @@ rec {
           "alpn" = [ "native-tls/alpn" ];
           "vendored" = [ "native-tls/vendored" ];
         };
-      };
-      "hyper-util" = rec {
-        crateName = "hyper-util";
-        version = "0.1.3";
-        edition = "2021";
-        sha256 = "1akngan7j0n2n0wd25c6952mvqbkj9gp1lcwzyxjc0d37l8yyf6a";
-        authors = [
-          "Sean McArthur <sean@seanmonstar.com>"
-        ];
-        dependencies = [
-          {
-            name = "bytes";
-            packageId = "bytes";
-          }
-          {
-            name = "futures-channel";
-            packageId = "futures-channel";
-            optional = true;
-          }
-          {
-            name = "futures-util";
-            packageId = "futures-util";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "http";
-            packageId = "http";
-          }
-          {
-            name = "http-body";
-            packageId = "http-body";
-          }
-          {
-            name = "hyper";
-            packageId = "hyper";
-          }
-          {
-            name = "pin-project-lite";
-            packageId = "pin-project-lite";
-          }
-          {
-            name = "socket2";
-            packageId = "socket2";
-            optional = true;
-            features = [ "all" ];
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            optional = true;
-            features = [ "net" "rt" "time" ];
-          }
-          {
-            name = "tower";
-            packageId = "tower";
-            optional = true;
-            features = [ "make" "util" ];
-          }
-          {
-            name = "tower-service";
-            packageId = "tower-service";
-            optional = true;
-          }
-          {
-            name = "tracing";
-            packageId = "tracing";
-            optional = true;
-            usesDefaultFeatures = false;
-            features = [ "std" ];
-          }
-          {
-            name = "tower-service";
-            packageId = "tower-service";
-          }
-        ];
-        devDependencies = [
-          {
-            name = "hyper-util";
-            packageId = "hyper-util";
-            features = [ "http1" ];
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            features = [ "macros" "test-util" ];
-          }
-        ];
-        features = {
-          "alpn" = [ "native-tls/alpn" ];
-          "vendored" = [ "native-tls/vendored" ];
-        };
-        resolvedDefaultFeatures = [ "client" "client-legacy" "default" "http1" "http2" "server" "tokio" ];
       };
       "hyper-util" = rec {
         crateName = "hyper-util";
@@ -7857,13 +7669,13 @@ rec {
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.69.0";
+        version = "0.69.1";
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "9ff61fa29c30b5aedc5c11b929079477e2642a7a";
-          sha256 = "033zxfdwf202h48lshnw9wznbrkl80px8rdcg4h0rcb0wc2pa37q";
+          rev = "3e543e6a3783c025956f348d86cd5369a132e52f";
+          sha256 = "1klavf7i3nvha2v0nr027kss8q4sq4lc42z5n5pnfmiv0yz4mq9l";
         };
         authors = [
           "Stackable GmbH <info@stackable.de>"
@@ -8011,8 +7823,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "9ff61fa29c30b5aedc5c11b929079477e2642a7a";
-          sha256 = "033zxfdwf202h48lshnw9wznbrkl80px8rdcg4h0rcb0wc2pa37q";
+          rev = "3e543e6a3783c025956f348d86cd5369a132e52f";
+          sha256 = "1klavf7i3nvha2v0nr027kss8q4sq4lc42z5n5pnfmiv0yz4mq9l";
         };
         procMacro = true;
         authors = [

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -7669,13 +7669,13 @@ rec {
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.69.1";
+        version = "0.69.2";
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "3e543e6a3783c025956f348d86cd5369a132e52f";
-          sha256 = "1klavf7i3nvha2v0nr027kss8q4sq4lc42z5n5pnfmiv0yz4mq9l";
+          rev = "9dcd255edee85e24c6a131ad4d61b17654ddf7c9";
+          sha256 = "0db8i14l5961hbbnyjsi754vpxalpv95dy3q3vylrga6yh288a5b";
         };
         authors = [
           "Stackable GmbH <info@stackable.de>"
@@ -7823,8 +7823,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "3e543e6a3783c025956f348d86cd5369a132e52f";
-          sha256 = "1klavf7i3nvha2v0nr027kss8q4sq4lc42z5n5pnfmiv0yz4mq9l";
+          rev = "9dcd255edee85e24c6a131ad4d61b17654ddf7c9";
+          sha256 = "0db8i14l5961hbbnyjsi754vpxalpv95dy3q3vylrga6yh288a5b";
         };
         procMacro = true;
         authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = "0.8"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.69.1" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.69.2" }
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.37", features = ["full"] }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = "0.8"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.69.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.69.1" }
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.37", features = ["full"] }
 tracing = "0.1"

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,5 +1,5 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.0#stackable-operator-derive@0.3.0": "033zxfdwf202h48lshnw9wznbrkl80px8rdcg4h0rcb0wc2pa37q",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.0#stackable-operator@0.69.0": "033zxfdwf202h48lshnw9wznbrkl80px8rdcg4h0rcb0wc2pa37q",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.1#stackable-operator-derive@0.3.0": "1klavf7i3nvha2v0nr027kss8q4sq4lc42z5n5pnfmiv0yz4mq9l",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.1#stackable-operator@0.69.1": "1klavf7i3nvha2v0nr027kss8q4sq4lc42z5n5pnfmiv0yz4mq9l",
   "git+https://github.com/stackabletech/product-config.git?tag=0.6.0#product-config@0.6.0": "1ixc2x7540sxdmc92hqdcwm24rj8i1ivjsvwk2d57pdsq03j2x41"
 }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,5 +1,5 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.1#stackable-operator-derive@0.3.0": "1klavf7i3nvha2v0nr027kss8q4sq4lc42z5n5pnfmiv0yz4mq9l",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.1#stackable-operator@0.69.1": "1klavf7i3nvha2v0nr027kss8q4sq4lc42z5n5pnfmiv0yz4mq9l",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.2#stackable-operator-derive@0.3.0": "0db8i14l5961hbbnyjsi754vpxalpv95dy3q3vylrga6yh288a5b",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.69.2#stackable-operator@0.69.2": "0db8i14l5961hbbnyjsi754vpxalpv95dy3q3vylrga6yh288a5b",
   "git+https://github.com/stackabletech/product-config.git?tag=0.6.0#product-config@0.6.0": "1ixc2x7540sxdmc92hqdcwm24rj8i1ivjsvwk2d57pdsq03j2x41"
 }

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1062,10 +1062,10 @@ fn build_opa_start_command(merged_config: &OpaConfig, container_name: &str) -> S
 
     let logging_redirects = format!(
         "&> >(CONSOLE_LEVEL={console} FILE_LEVEL={file} DECISION_LEVEL={decision} SERVER_LEVEL={server} OPA_ROLLING_LOG_FILE_SIZE_BYTES={OPA_ROLLING_LOG_FILE_SIZE_BYTES} OPA_ROLLING_LOG_FILES={OPA_ROLLING_LOG_FILES} STACKABLE_LOG_DIR={STACKABLE_LOG_DIR} CONTAINER_NAME={container_name} process-logs)",
-        file = file_log_level.to_opa_literal(),
-        console = console_log_level.to_opa_literal(),
-        decision = decision_log_level.to_opa_literal(),
-        server = server_log_level.to_opa_literal()
+        file = file_log_level,
+        console = console_log_level,
+        decision = decision_log_level,
+        server = server_log_level
     );
 
     // TODO: Think about adding --shutdown-wait-period, as suggested by https://github.com/open-policy-agent/opa/issues/2764


### PR DESCRIPTION
# Description

Forward the correct log level to log processing. `to_opa_literal()` converts to opa log levels, which only include a subset of possible log levels, and this results in undesired behavior. For example `LogLevel::NONE` would be converted to `error`, which means error logs would not be filtered out. This PR fixes that.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
