### PR TITLE
docs: remove home module from refs (stackabletech/documentation#637) / 23.1

### DIFF
--- a/docs/modules/opa/pages/usage.adoc
+++ b/docs/modules/opa/pages/usage.adoc
@@ -68,7 +68,7 @@ data:
 == Monitoring
 
 The managed OPA instances are automatically configured to export Prometheus metrics. See
-xref:home:operators:monitoring.adoc[] for more details.
+xref:operators:monitoring.adoc[] for more details.
 
 == Configuration & Environment Overrides
 
@@ -117,7 +117,7 @@ The OPA Operator currently does not support using https://kubernetes.io/docs/con
 // The "nightly" version is needed because the "include" directive searches for
 // files in the "stable" version by default.
 // TODO: remove the "nightly" version after the next platform release (current: 22.09)
-include::home:concepts:stackable_resource_requests.adoc[]
+include::concepts:stackable_resource_requests.adoc[]
 
 If no resource requests are configured explicitly, the OPA operator uses the following defaults:
 


### PR DESCRIPTION
# Description

docs: remove home module from refs (stackabletech/documentation#637)