### PR TITLE
fix(kuttl tests): Use bundled userinfo rego utility

### DIFF
--- a/tests/templates/kuttl/aas-user-info/10-install-opa.yaml.j2
+++ b/tests/templates/kuttl/aas-user-info/10-install-opa.yaml.j2
@@ -5,6 +5,22 @@ commands:
   - script: |
       kubectl apply -n $NAMESPACE -f - <<EOF
       ---
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test
+        labels:
+          opa.stackable.tech/bundle: "true"
+      data:
+        test.rego: |
+          package test
+
+          userInfoByUsername(username) := http.send({"method": "POST", "url": "http://127.0.0.1:9476/user", "body": {"username": username}, "headers": {"Content-Type": "application/json"}, "raise_error": true}).body
+          userInfoById(id) := http.send({"method": "POST", "url": "http://127.0.0.1:9476/user", "body": {"id": id}, "headers": {"Content-Type": "application/json"}, "raise_error": true}).body
+
+          currentUserInfoByUsername := userInfoByUsername(input.username)
+          currentUserInfoById := userInfoById(input.id)
+      ---
       apiVersion: opa.stackable.tech/v1alpha1
       kind: OpaCluster
       metadata:

--- a/tests/templates/kuttl/aas-user-info/10-install-opa.yaml.j2
+++ b/tests/templates/kuttl/aas-user-info/10-install-opa.yaml.j2
@@ -15,11 +15,10 @@ commands:
         test.rego: |
           package test
 
-          userInfoByUsername(username) := http.send({"method": "POST", "url": "http://127.0.0.1:9476/user", "body": {"username": username}, "headers": {"Content-Type": "application/json"}, "raise_error": true}).body
-          userInfoById(id) := http.send({"method": "POST", "url": "http://127.0.0.1:9476/user", "body": {"id": id}, "headers": {"Content-Type": "application/json"}, "raise_error": true}).body
+          import data.stackable.opa.userinfo.v1 as userinfo
 
-          currentUserInfoByUsername := userInfoByUsername(input.username)
-          currentUserInfoById := userInfoById(input.id)
+          currentUserInfoByUsername := userinfo.userInfoByUsername(input.username)
+          currentUserInfoById := userinfo.userInfoById(input.id)
       ---
       apiVersion: opa.stackable.tech/v1alpha1
       kind: OpaCluster

--- a/tests/templates/kuttl/aas-user-info/30-assert.yaml
+++ b/tests/templates/kuttl/aas-user-info/30-assert.yaml
@@ -4,4 +4,4 @@ kind: TestAssert
 metadata:
   name: test-regorule
 commands:
-  - script: kubectl exec -n $NAMESPACE test-regorule-0 -- python /tmp/test-regorule.py -u 'http://test-opa-server-default:8081/v1/data/stackable/opa/userinfo/v1'
+  - script: kubectl exec -n $NAMESPACE test-regorule-0 -- python /tmp/test-regorule.py -u 'http://test-opa-server-default:8081/v1/data/test'

--- a/tests/templates/kuttl/aas-user-info/test-regorule.py
+++ b/tests/templates/kuttl/aas-user-info/test-regorule.py
@@ -8,23 +8,24 @@ def assertions(
     username, response, opa_attribute, expected_groups, expected_attributes={}
 ):
     assert "result" in response
-    assert opa_attribute in response["result"]
+    result = response["result"]
+    assert opa_attribute in result, f"expected {opa_attribute} in {result}"
 
     # repeated the right hand side for better output on error
-    assert "customAttributes" in response["result"][opa_attribute]
-    assert "groups" in response["result"][opa_attribute]
-    assert "id" in response["result"][opa_attribute]
-    assert "username" in response["result"][opa_attribute]
+    assert "customAttributes" in result[opa_attribute]
+    assert "groups" in result[opa_attribute]
+    assert "id" in result[opa_attribute]
+    assert "username" in result[opa_attribute]
 
     # todo: split out group assertions
     print(f"Testing for {username} in groups {expected_groups}")
-    groups = sorted(response["result"][opa_attribute]["groups"])
+    groups = sorted(result[opa_attribute]["groups"])
     expected_groups = sorted(expected_groups)
     assert groups == expected_groups, f"got {groups}, expected: {expected_groups}"
 
     # todo: split out customAttribute assertions
     print(f"Testing for {username} with customAttributes {expected_attributes}")
-    custom_attributes = response["result"][opa_attribute]["customAttributes"]
+    custom_attributes = result[opa_attribute]["customAttributes"]
     assert (
         custom_attributes == expected_attributes
     ), f"got {custom_attributes}, expected: {expected_attributes}"
@@ -37,9 +38,12 @@ if __name__ == "__main__":
     params = {"strict-builtin-errors": "true"}
 
     def make_request(payload):
-        return requests.post(
-            args["url"], data=json.dumps(payload), params=params
-        ).json()
+        response = requests.post(args["url"], data=json.dumps(payload), params=params)
+        expected_status_code = 200
+        assert (
+            response.status_code == expected_status_code
+        ), f"got {response.status_code}, expected: {expected_status_code}"
+        return response.json()
 
     for subject_id in ["alice", "bob"]:
         try:

--- a/tests/templates/kuttl/aas-user-info/test-regorule.py
+++ b/tests/templates/kuttl/aas-user-info/test-regorule.py
@@ -4,7 +4,9 @@ import argparse
 import json
 
 
-def assertions(username, response, opa_attribute, expected_groups, expected_attributes={}):
+def assertions(
+    username, response, opa_attribute, expected_groups, expected_attributes={}
+):
     assert "result" in response
     assert opa_attribute in response["result"]
 
@@ -23,25 +25,35 @@ def assertions(username, response, opa_attribute, expected_groups, expected_attr
     # todo: split out customAttribute assertions
     print(f"Testing for {username} with customAttributes {expected_attributes}")
     custom_attributes = response["result"][opa_attribute]["customAttributes"]
-    assert custom_attributes == expected_attributes, f"got {custom_attributes}, expected: {expected_attributes}"
+    assert (
+        custom_attributes == expected_attributes
+    ), f"got {custom_attributes}, expected: {expected_attributes}"
 
 
 if __name__ == "__main__":
     all_args = argparse.ArgumentParser()
     all_args.add_argument("-u", "--url", required=True, help="OPA service url")
     args = vars(all_args.parse_args())
-    params = {'strict-builtin-errors': 'true'}
+    params = {"strict-builtin-errors": "true"}
 
     def make_request(payload):
-        return requests.post(args['url'], data=json.dumps(payload), params=params).json()
+        return requests.post(
+            args["url"], data=json.dumps(payload), params=params
+        ).json()
 
     for subject_id in ["alice", "bob"]:
         try:
             # todo: try this out locally until it works
             # url = 'http://test-opa-svc:8081/v1/data'
-            payload = {'input': {'id': subject_id}}
+            payload = {"input": {"id": subject_id}}
             response = make_request(payload)
-            assertions(subject_id, response, "currentUserInfoById", [], {"e-mail": f"{subject_id}@example.com", "company": "openid"})
+            assertions(
+                subject_id,
+                response,
+                "currentUserInfoById",
+                [],
+                {"e-mail": f"{subject_id}@example.com", "company": "openid"},
+            )
         except Exception as e:
             print(f"exception: {e}")
             if response is not None:

--- a/tests/templates/kuttl/aas-user-info/test-regorule.py
+++ b/tests/templates/kuttl/aas-user-info/test-regorule.py
@@ -43,8 +43,10 @@ if __name__ == "__main__":
             response = make_request(payload)
             assertions(subject_id, response, "currentUserInfoById", [], {"e-mail": f"{subject_id}@example.com", "company": "openid"})
         except Exception as e:
+            print(f"exception: {e}")
             if response is not None:
-                print(f"something went wrong. last response: {response}")
+                print(f"request  body: {payload}")
+                print(f"response body: {response}")
             raise e
 
     print("Test successful!")

--- a/tests/templates/kuttl/keycloak-user-info/10-install-opa.yaml.j2
+++ b/tests/templates/kuttl/keycloak-user-info/10-install-opa.yaml.j2
@@ -5,6 +5,22 @@ commands:
   - script: |
       kubectl apply -n $NAMESPACE -f - <<EOF
       ---
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test
+        labels:
+          opa.stackable.tech/bundle: "true"
+      data:
+        test.rego: |
+          package test
+
+          userInfoByUsername(username) := http.send({"method": "POST", "url": "http://127.0.0.1:9476/user", "body": {"username": username}, "headers": {"Content-Type": "application/json"}, "raise_error": true}).body
+          userInfoById(id) := http.send({"method": "POST", "url": "http://127.0.0.1:9476/user", "body": {"id": id}, "headers": {"Content-Type": "application/json"}, "raise_error": true}).body
+
+          currentUserInfoByUsername := userInfoByUsername(input.username)
+          currentUserInfoById := userInfoById(input.id)
+      ---
       apiVersion: opa.stackable.tech/v1alpha1
       kind: OpaCluster
       metadata:

--- a/tests/templates/kuttl/keycloak-user-info/10-install-opa.yaml.j2
+++ b/tests/templates/kuttl/keycloak-user-info/10-install-opa.yaml.j2
@@ -15,11 +15,10 @@ commands:
         test.rego: |
           package test
 
-          userInfoByUsername(username) := http.send({"method": "POST", "url": "http://127.0.0.1:9476/user", "body": {"username": username}, "headers": {"Content-Type": "application/json"}, "raise_error": true}).body
-          userInfoById(id) := http.send({"method": "POST", "url": "http://127.0.0.1:9476/user", "body": {"id": id}, "headers": {"Content-Type": "application/json"}, "raise_error": true}).body
+          import data.stackable.opa.userinfo.v1 as userinfo
 
-          currentUserInfoByUsername := userInfoByUsername(input.username)
-          currentUserInfoById := userInfoById(input.id)
+          currentUserInfoByUsername := userinfo.userInfoByUsername(input.username)
+          currentUserInfoById := userinfo.userInfoById(input.id)
       ---
       apiVersion: opa.stackable.tech/v1alpha1
       kind: OpaCluster

--- a/tests/templates/kuttl/keycloak-user-info/30-assert.yaml
+++ b/tests/templates/kuttl/keycloak-user-info/30-assert.yaml
@@ -4,4 +4,4 @@ kind: TestAssert
 metadata:
   name: test-regorule
 commands:
-  - script: kubectl exec -n $NAMESPACE test-regorule-0 -- python /tmp/test-regorule.py -u 'http://test-opa-server-default:8081/v1/data/stackable/opa/userinfo/v1'
+  - script: kubectl exec -n $NAMESPACE test-regorule-0 -- python /tmp/test-regorule.py -u 'http://test-opa-server-default:8081/v1/data/test'

--- a/tests/templates/kuttl/keycloak-user-info/test-regorule.py
+++ b/tests/templates/kuttl/keycloak-user-info/test-regorule.py
@@ -55,8 +55,10 @@ if __name__ == "__main__":
             response = make_request(payload)
             assertions(username, response, "currentUserInfoById", groups, {})
         except Exception as e:
+            print(f"exception: {e}")
             if response is not None:
-                print(f"something went wrong. last response: {response}")
+                print(f"request  body: {payload}")
+                print(f"response body: {response}")
             raise e
 
     print("Test successful!")

--- a/tests/templates/kuttl/keycloak-user-info/test-regorule.py
+++ b/tests/templates/kuttl/keycloak-user-info/test-regorule.py
@@ -10,7 +10,9 @@ users_and_groups = {
 }
 
 
-def assertions(username, response, opa_attribute, expected_groups, expected_attributes={}):
+def assertions(
+    username, response, opa_attribute, expected_groups, expected_attributes={}
+):
     assert "result" in response
     assert opa_attribute in response["result"]
 
@@ -29,29 +31,33 @@ def assertions(username, response, opa_attribute, expected_groups, expected_attr
     # todo: split out customAttribute assertions
     print(f"Testing for {username} with customAttributes {expected_attributes}")
     custom_attributes = response["result"][opa_attribute]["customAttributes"]
-    assert custom_attributes == expected_attributes, f"got {custom_attributes}, expected: {expected_attributes}"
+    assert (
+        custom_attributes == expected_attributes
+    ), f"got {custom_attributes}, expected: {expected_attributes}"
 
 
 if __name__ == "__main__":
     all_args = argparse.ArgumentParser()
     all_args.add_argument("-u", "--url", required=True, help="OPA service url")
     args = vars(all_args.parse_args())
-    params = {'strict-builtin-errors': 'true'}
+    params = {"strict-builtin-errors": "true"}
 
     def make_request(payload):
-        return requests.post(args['url'], data=json.dumps(payload), params=params).json()
+        return requests.post(
+            args["url"], data=json.dumps(payload), params=params
+        ).json()
 
     for username, groups in users_and_groups.items():
         try:
             # todo: try this out locally until it works
             # url = 'http://test-opa-svc:8081/v1/data'
-            payload = {'input': {'username': username}}
+            payload = {"input": {"username": username}}
             response = make_request(payload)
             assertions(username, response, "currentUserInfoByUsername", groups, {})
 
             # do the reverse lookup
             user_id = response["result"]["currentUserInfoByUsername"]["id"]
-            payload = {'input': {'id': user_id}}
+            payload = {"input": {"id": user_id}}
             response = make_request(payload)
             assertions(username, response, "currentUserInfoById", groups, {})
         except Exception as e:

--- a/tests/templates/kuttl/keycloak-user-info/test-regorule.py
+++ b/tests/templates/kuttl/keycloak-user-info/test-regorule.py
@@ -14,23 +14,24 @@ def assertions(
     username, response, opa_attribute, expected_groups, expected_attributes={}
 ):
     assert "result" in response
-    assert opa_attribute in response["result"]
+    result = response["result"]
+    assert opa_attribute in result, f"expected {opa_attribute} in {result}"
 
     # repeated the right hand side for better output on error
-    assert "customAttributes" in response["result"][opa_attribute]
-    assert "groups" in response["result"][opa_attribute]
-    assert "id" in response["result"][opa_attribute]
-    assert "username" in response["result"][opa_attribute]
+    assert "customAttributes" in result[opa_attribute]
+    assert "groups" in result[opa_attribute]
+    assert "id" in result[opa_attribute]
+    assert "username" in result[opa_attribute]
 
     # todo: split out group assertions
     print(f"Testing for {username} in groups {expected_groups}")
-    groups = sorted(response["result"][opa_attribute]["groups"])
+    groups = sorted(result[opa_attribute]["groups"])
     expected_groups = sorted(expected_groups)
     assert groups == expected_groups, f"got {groups}, expected: {expected_groups}"
 
     # todo: split out customAttribute assertions
     print(f"Testing for {username} with customAttributes {expected_attributes}")
-    custom_attributes = response["result"][opa_attribute]["customAttributes"]
+    custom_attributes = result[opa_attribute]["customAttributes"]
     assert (
         custom_attributes == expected_attributes
     ), f"got {custom_attributes}, expected: {expected_attributes}"
@@ -43,9 +44,12 @@ if __name__ == "__main__":
     params = {"strict-builtin-errors": "true"}
 
     def make_request(payload):
-        return requests.post(
-            args["url"], data=json.dumps(payload), params=params
-        ).json()
+        response = requests.post(args["url"], data=json.dumps(payload), params=params)
+        expected_status_code = 200
+        assert (
+            response.status_code == expected_status_code
+        ), f"got {response.status_code}, expected: {expected_status_code}"
+        return response.json()
 
     for username, groups in users_and_groups.items():
         try:


### PR DESCRIPTION
Fixes the [test failures] (see [slack thread]):

_The effective fixes were cd3c31ed8bfff588fe2cc68c23a258a080f5ce65 and 7c308cc6f0959ffe353bab57ebd4a590cbf20866_

```
Traceback (most recent call last):
  File "/tmp/test-regorule.py", line 60, in <module>
    raise e
  File "/tmp/test-regorule.py", line 50, in <module>
something went wrong. last response: {'result': {}}
    assertions(username, response, 
```

- Use the bundled userinfo rego utility (partially reverts #580)
- Improve the output of the test scripts
  - print out the exception, it will have more information (from the `assertions()` function).
  - ruff formatting

[test failures]: https://testing.stackable.tech/job/opa-operator-it-weekly/13/console
[slack thread]: https://stackable-workspace.slack.com/archives/C02M1RE8S0Z/p1723187622613479