### PR TITLE
Add internal trafific policy 'Cluster' role service and discovery CM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 - Run a `containerdebug` process in the background of each OPA container to collect debugging information ([#666]).
 - Added support for OPA `1.0.x` ([#677]) and ([#687]).
 - Aggregate emitted Kubernetes events on the CustomResources ([#675]).
-- Added role level service and discovery configmap called `<cluster-name>-lb` with `internalTrafficPolicy` set to "Cluster" ([#688]).
+- Added role level services and discovery configmaps called `<cluster-name>-local` with `internalTrafficPolicy` set to `Local`
+  and `<cluster-name>-cluster` with `internalTrafficPolicy` set to `Cluster` ([#688]). 
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Run a `containerdebug` process in the background of each OPA container to collect debugging information ([#666]).
 - Added support for OPA `1.0.x` ([#677]) and ([#687]).
 - Aggregate emitted Kubernetes events on the CustomResources ([#675]).
+- Added role level service and discovery configmap called `<cluster-name>-lb` with `internalTrafficPolicy` set to "Cluster" ([#688]).
 
 ### Removed
 
@@ -23,6 +24,7 @@ All notable changes to this project will be documented in this file.
 [#675]: https://github.com/stackabletech/opa-operator/pull/675
 [#677]: https://github.com/stackabletech/opa-operator/pull/677
 [#687]: https://github.com/stackabletech/opa-operator/pull/687
+[#688]: https://github.com/stackabletech/opa-operator/pull/688
 
 ## [24.11.1] - 2025-01-10
 

--- a/docs/modules/opa/pages/implementation-notes.adoc
+++ b/docs/modules/opa/pages/implementation-notes.adoc
@@ -5,10 +5,24 @@ but should not be required reading for regular use.
 
 == OPA replica per node
 
+Since OPA is deployed as a DaemonSet and runs on each Node, two entrypoint Services are defined.
+
+=== Local Traffic Policy
+
 OPA runs on each Node to avoid requiring network round trips for services making policy queries (which are often chained in serial, and block other tasks in the products).
 
 Local access is ensured via an https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/[`InternalTrafficPolicy`].
 This means that https://kubernetes.io/docs/concepts/workloads/pods/[Pods] accessing OPA via the service discovery are routed to the OPA Pod on the same https://kubernetes.io/docs/concepts/architecture/nodes/[Node] to reduce request latency and network traffic.
+
+This should be the default entrypoint and has the same name as the defined OPA cluster. If the `metadata.name` is `opa`, this service is called `opa`.
+
+=== Cluster Traffic Policy (load-balanced / round-robin)
+
+This service is called as the OPA cluster suffixed with `-lb`. This entrypoint can be used if latency (e.g. no network requests) is less important. 
+Evaluating complicated rego rules may take some time depending on the provided resources, and can be the limiting factor in e.g. bulk requests.
+Therefore, using this service, every Pod in the cluster is utilized to evaluate policies than instead e.g. just one.
+
+If the `metadata.name` if `opa`, this service is called `opa-lb`.
 
 == OPA Bundle Builder
 

--- a/docs/modules/opa/pages/implementation-notes.adoc
+++ b/docs/modules/opa/pages/implementation-notes.adoc
@@ -5,7 +5,7 @@ but should not be required reading for regular use.
 
 == OPA replica per node
 
-Since OPA is deployed as a DaemonSet and runs on each Node, two entrypoint Services are defined.
+OPA is deployed as a DaemonSet and runs on each Node. two entrypoint Services are defined.
 
 === Local Traffic Policy
 
@@ -16,15 +16,16 @@ This means that https://kubernetes.io/docs/concepts/workloads/pods/[Pods] access
 
 This should be the default entrypoint and has the same name as the defined OPA cluster.
 
-If the `metadata.name` is `opa`, this service is called `opa`.
+If the `metadata.name` is `opa`, this service is called `opa-local`.
 
-=== Cluster Traffic Policy (load-balanced / round-robin)
+=== Cluster Traffic Policy (round-robin)
 
-This service is called as the OPA cluster suffixed with `-lb`. This entrypoint can be used if latency (e.g. no network requests) is less important.
+This service is called as the OPA cluster suffixed with `-cluster`. This entrypoint can be used if latency (e.g. no network requests) is less important.
 Evaluating complicated rego rules may take some time depending on the provided resources, and can be the limiting factor in e.g. bulk requests.
-Therefore, using this service, every Pod in the cluster is utilized to evaluate policies than instead e.g. just one.
+Therefore, using this service, every Pod in the cluster is utilized to evaluate policies (via round robin). This allows better parallelism when
+evaluating policies, but results in network roundtrips.
 
-If the `metadata.name` is `opa`, this service is called `opa-lb`.
+If the `metadata.name` is `opa`, this service is called `opa-cluster`.
 
 == OPA Bundle Builder
 

--- a/docs/modules/opa/pages/implementation-notes.adoc
+++ b/docs/modules/opa/pages/implementation-notes.adoc
@@ -5,7 +5,7 @@ but should not be required reading for regular use.
 
 == OPA replica per node
 
-OPA is deployed as a DaemonSet and runs on each Node. two entrypoint Services are defined.
+OPA is deployed as a DaemonSet and runs on each Node. The following entrypoint Services are defined:
 
 === Local Traffic Policy
 

--- a/docs/modules/opa/pages/implementation-notes.adoc
+++ b/docs/modules/opa/pages/implementation-notes.adoc
@@ -14,7 +14,9 @@ OPA runs on each Node to avoid requiring network round trips for services making
 Local access is ensured via an https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/[`InternalTrafficPolicy`].
 This means that https://kubernetes.io/docs/concepts/workloads/pods/[Pods] accessing OPA via the service discovery are routed to the OPA Pod on the same https://kubernetes.io/docs/concepts/architecture/nodes/[Node] to reduce request latency and network traffic.
 
-This should be the default entrypoint and has the same name as the defined OPA cluster. If the `metadata.name` is `opa`, this service is called `opa`.
+This should be the default entrypoint and has the same name as the defined OPA cluster. 
+
+If the `metadata.name` is `opa`, this service is called `opa`.
 
 === Cluster Traffic Policy (load-balanced / round-robin)
 
@@ -22,7 +24,7 @@ This service is called as the OPA cluster suffixed with `-lb`. This entrypoint c
 Evaluating complicated rego rules may take some time depending on the provided resources, and can be the limiting factor in e.g. bulk requests.
 Therefore, using this service, every Pod in the cluster is utilized to evaluate policies than instead e.g. just one.
 
-If the `metadata.name` if `opa`, this service is called `opa-lb`.
+If the `metadata.name` is `opa`, this service is called `opa-lb`.
 
 == OPA Bundle Builder
 

--- a/docs/modules/opa/pages/implementation-notes.adoc
+++ b/docs/modules/opa/pages/implementation-notes.adoc
@@ -14,13 +14,13 @@ OPA runs on each Node to avoid requiring network round trips for services making
 Local access is ensured via an https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/[`InternalTrafficPolicy`].
 This means that https://kubernetes.io/docs/concepts/workloads/pods/[Pods] accessing OPA via the service discovery are routed to the OPA Pod on the same https://kubernetes.io/docs/concepts/architecture/nodes/[Node] to reduce request latency and network traffic.
 
-This should be the default entrypoint and has the same name as the defined OPA cluster. 
+This should be the default entrypoint and has the same name as the defined OPA cluster.
 
 If the `metadata.name` is `opa`, this service is called `opa`.
 
 === Cluster Traffic Policy (load-balanced / round-robin)
 
-This service is called as the OPA cluster suffixed with `-lb`. This entrypoint can be used if latency (e.g. no network requests) is less important. 
+This service is called as the OPA cluster suffixed with `-lb`. This entrypoint can be used if latency (e.g. no network requests) is less important.
 Evaluating complicated rego rules may take some time depending on the provided resources, and can be the limiting factor in e.g. bulk requests.
 Therefore, using this service, every Pod in the cluster is utilized to evaluate policies than instead e.g. just one.
 

--- a/docs/modules/opa/pages/reference/discovery.adoc
+++ b/docs/modules/opa/pages/reference/discovery.adoc
@@ -31,7 +31,7 @@ spec:
 
 Currently, three discovery ConfigMaps are provided.
 
-=== (DEPRECATED) Internal Traffic Policy `Local` 
+=== (DEPRECATED) Internal Traffic Policy `Local`
 
 The discovery ConfigMap `{namespace}/{clusterName}` contains the following fields where `{clusterName}` represents the name and `{namespace}` the namespace of the cluster.
 This is deprecated and only kept for backwards compatibitliy. Users are adviced to switch to `{namespace}/{clusterName}-local`, which is the identical replacement.
@@ -51,7 +51,7 @@ In order to query policies you have to configure your product and its OPA URL as
     http://{clusterName}.{namespace}.svc.cluster.local:8081/v1/data/{packageName}/{policyName}
 ====
 
-=== Internal Traffic Policy `Local` 
+=== Internal Traffic Policy `Local`
 
 The discovery ConfigMap `{namespace}/{clusterName}-local` contains the following fields where `{clusterName}-local` represents the name and `{namespace}` the namespace of the cluster.
 Using this discovery service, requests from one Node will always reach the OPA Pod on the same Node. This allows for low latency authorization queriers.
@@ -71,7 +71,7 @@ In order to query policies you have to configure your product and its OPA URL as
     http://{clusterName}-local.{namespace}.svc.cluster.local:8081/v1/data/{packageName}/{policyName}
 ====
 
-=== Internal Traffic Policy `Cluster` 
+=== Internal Traffic Policy `Cluster`
 
 The discovery ConfigMap `{namespace}/{clusterName}-cluster` contains the following fields where `{clusterName}-cluster` represents the name and `{namespace}` the namespace of the cluster.
 Using this discovery service, requests to OPA are distributed over all available OPA Pods, improving parallelism when evaluating policies but slightly increasing the latency of each single query

--- a/docs/modules/opa/pages/reference/discovery.adoc
+++ b/docs/modules/opa/pages/reference/discovery.adoc
@@ -26,14 +26,15 @@ metadata:
 spec:
   [...]
 ----
-<1> The name of the OPA cluster, which is also the name of the created discovery ConfigMap.
-<2> The namespace of the discovery ConfigMap.
+<1> The name of the OPA cluster, which is used in the created discovery ConfigMaps.
+<2> The namespace of the discovery ConfigMaps.
 
-The resulting discovery ConfigMap is `{namespace}/{clusterName}`.
+Currently, three discovery ConfigMaps are provided.
 
-== Contents
+=== (DEPRECATED) Internal Traffic Policy `Local` 
 
-The `{namespace}/{clusterName}` discovery ConfigMap contains the following fields where `{clusterName}` represents the name and `{namespace}` the namespace of the cluster:
+The discovery ConfigMap `{namespace}/{clusterName}` contains the following fields where `{clusterName}` represents the name and `{namespace}` the namespace of the cluster.
+This is deprecated and only kept for backwards compatibitliy. Users are adviced to switch to `{namespace}/{clusterName}-local`, which is the identical replacement.
 
 `OPA`::
 ====
@@ -48,4 +49,45 @@ In order to query policies you have to configure your product and its OPA URL as
 
 [subs="attributes"]
     http://{clusterName}.{namespace}.svc.cluster.local:8081/v1/data/{packageName}/{policyName}
+====
+
+=== Internal Traffic Policy `Local` 
+
+The discovery ConfigMap `{namespace}/{clusterName}-local` contains the following fields where `{clusterName}-local` represents the name and `{namespace}` the namespace of the cluster.
+Using this discovery service, requests from one Node will always reach the OPA Pod on the same Node. This allows for low latency authorization queriers.
+
+`OPA`::
+====
+A connection string for cluster internal OPA requests.
+Provided the cluster example above, the connection string is created as follows:
+
+[subs="attributes"]
+    http://{clusterName}-local.{namespace}.svc.cluster.local:8081/
+
+This connection string points to the base URL (and web UI) of the OPA cluster.
+In order to query policies you have to configure your product and its OPA URL as follows, given the bundle package name `{packageName}` and the policy name `{policyName}`:
+
+[subs="attributes"]
+    http://{clusterName}-local.{namespace}.svc.cluster.local:8081/v1/data/{packageName}/{policyName}
+====
+
+=== Internal Traffic Policy `Cluster` 
+
+The discovery ConfigMap `{namespace}/{clusterName}-cluster` contains the following fields where `{clusterName}-cluster` represents the name and `{namespace}` the namespace of the cluster.
+Using this discovery service, requests to OPA are distributed over all available OPA Pods, improving parallelism when evaluating policies but slightly increasing the latency of each single query
+to due additional network requests.
+
+`OPA`::
+====
+A connection string for cluster internal OPA requests.
+Provided the cluster example above, the connection string is created as follows:
+
+[subs="attributes"]
+    http://{clusterName}-cluster.{namespace}.svc.cluster.local:8081/
+
+This connection string points to the base URL (and web UI) of the OPA cluster.
+In order to query policies you have to configure your product and its OPA URL as follows, given the bundle package name `{packageName}` and the policy name `{policyName}`:
+
+[subs="attributes"]
+    http://{clusterName}-cluster.{namespace}.svc.cluster.local:8081/v1/data/{packageName}/{policyName}
 ====

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -158,9 +158,6 @@ pub enum Error {
         source: error_boundary::InvalidObject,
     },
 
-    #[snafu(display("object does not define meta name"))]
-    NoName,
-
     #[snafu(display("internal operator failure"))]
     InternalOperatorFailure {
         source: stackable_opa_operator::crd::Error,
@@ -453,7 +450,7 @@ pub async fn reconcile_opa(
 
     let required_services = vec![
         // The server-role service is the primary endpoint that should be used by clients that do
-        // require local access - Deprecated, kept for downwards compatibility
+        // require local access - deprecated, kept for downwards compatibility
         ServiceConfig {
             name: opa
                 .server_role_service_name_itp_local_deprecated()

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -324,6 +324,14 @@ impl v1alpha1::OpaCluster {
         self.metadata.name.clone()
     }
 
+    /// The name of the role-level load-balanced Kubernetes `Service`
+    pub fn server_role_service_name_load_balanced(&self) -> Option<String> {
+        if let Some(service_name) = self.server_role_service_name() {
+            return Some(format!("{service_name}-lb"));
+        }
+        None
+    }
+
     /// The fully-qualified domain name of the role-level load-balanced Kubernetes `Service`
     pub fn server_role_service_fqdn(&self, cluster_info: &KubernetesClusterInfo) -> Option<String> {
         Some(format!(

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -319,24 +319,32 @@ impl v1alpha1::OpaCluster {
             })
     }
 
-    /// The name of the role-level load-balanced Kubernetes `Service`
-    pub fn server_role_service_name(&self) -> Option<String> {
+    /// DEPRECATED: The name of the role-level traffic policy local Kubernetes `Service`
+    pub fn server_role_service_name_itp_local_deprecated(&self) -> Option<String> {
         self.metadata.name.clone()
     }
 
-    /// The name of the role-level load-balanced Kubernetes `Service`
-    pub fn server_role_service_name_load_balanced(&self) -> Option<String> {
-        if let Some(service_name) = self.server_role_service_name() {
-            return Some(format!("{service_name}-lb"));
+    /// The name of the role-level traffic policy cluster Kubernetes `Service`
+    pub fn server_role_service_name_itp_local(&self) -> Option<String> {
+        if let Some(service_name) = &self.metadata.name {
+            return Some(format!("{service_name}-local"));
         }
         None
     }
 
-    /// The fully-qualified domain name of the role-level load-balanced Kubernetes `Service`
+    /// The name of the role-level traffic policy cluster Kubernetes `Service`
+    pub fn server_role_service_name_itp_cluster(&self) -> Option<String> {
+        if let Some(service_name) = &self.metadata.name {
+            return Some(format!("{service_name}-cluster"));
+        }
+        None
+    }
+
+    /// The fully-qualified domain name of the role-level local Kubernetes `Service`
     pub fn server_role_service_fqdn(&self, cluster_info: &KubernetesClusterInfo) -> Option<String> {
         Some(format!(
             "{role_service_name}.{namespace}.svc.{cluster_domain}",
-            role_service_name = self.server_role_service_name()?,
+            role_service_name = self.server_role_service_name_itp_local_deprecated()?,
             namespace = self.metadata.namespace.as_ref()?,
             cluster_domain = cluster_info.cluster_domain
         ))

--- a/rust/operator-binary/src/discovery.rs
+++ b/rust/operator-binary/src/discovery.rs
@@ -4,7 +4,7 @@ use stackable_operator::{
     builder::{configmap::ConfigMapBuilder, meta::ObjectMetaBuilder},
     commons::product_image_selection::ResolvedProductImage,
     k8s_openapi::api::core::v1::{ConfigMap, Service},
-    kube::{runtime::reflector::ObjectRef, Resource, ResourceExt},
+    kube::{runtime::reflector::ObjectRef, Resource},
     utils::cluster_info::KubernetesClusterInfo,
 };
 
@@ -35,27 +35,8 @@ pub enum Error {
     },
 }
 
-/// Builds discovery [`ConfigMap`]s for connecting to a [`v1alpha1::OpaCluster`] for all expected scenarios
-pub fn build_discovery_configmaps(
-    owner: &impl Resource<DynamicType = ()>,
-    opa: &v1alpha1::OpaCluster,
-    resolved_product_image: &ResolvedProductImage,
-    svc: &Service,
-    cluster_info: &KubernetesClusterInfo,
-) -> Result<Vec<ConfigMap>, Error> {
-    let name = owner.name_any();
-    Ok(vec![build_discovery_configmap(
-        &name,
-        owner,
-        opa,
-        resolved_product_image,
-        svc,
-        cluster_info,
-    )?])
-}
-
 /// Build a discovery [`ConfigMap`] containing information about how to connect to a certain [`v1alpha1::OpaCluster`]
-fn build_discovery_configmap(
+pub fn build_discovery_configmap(
     name: &str,
     owner: &impl Resource<DynamicType = ()>,
     opa: &v1alpha1::OpaCluster,

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -31,6 +31,7 @@ mod controller;
 mod discovery;
 mod operations;
 mod product_logging;
+mod service;
 
 pub mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));

--- a/rust/operator-binary/src/service.rs
+++ b/rust/operator-binary/src/service.rs
@@ -1,0 +1,185 @@
+use snafu::{ResultExt, Snafu};
+use stackable_opa_operator::crd::{v1alpha1, APP_NAME};
+use stackable_operator::{
+    builder::meta::ObjectMetaBuilder,
+    commons::product_image_selection::ResolvedProductImage,
+    k8s_openapi::{
+        api::core::v1::{Service, ServicePort, ServiceSpec},
+        apimachinery::pkg::util::intstr::IntOrString,
+    },
+    kube::runtime::reflector::ObjectRef,
+    kvp::{Label, LabelError, Labels},
+    role_utils::RoleGroupRef,
+};
+
+use crate::controller::{build_recommended_labels, APP_PORT, APP_PORT_NAME, METRICS_PORT_NAME};
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Snafu, Debug)]
+pub enum Error {
+    #[snafu(display("object {opa} is missing metadata to build owner reference"))]
+    ObjectMissingMetadataForOwnerRef {
+        source: stackable_operator::builder::meta::Error,
+        opa: ObjectRef<v1alpha1::OpaCluster>,
+    },
+
+    #[snafu(display("object has no name associated"))]
+    NoName,
+
+    #[snafu(display("object has no namespace associated"))]
+    NoNamespace,
+
+    #[snafu(display("failed to build ConfigMap"))]
+    BuildConfigMap {
+        source: stackable_operator::builder::configmap::Error,
+    },
+
+    #[snafu(display("failed to build object meta data"))]
+    ObjectMeta {
+        source: stackable_operator::builder::meta::Error,
+    },
+
+    #[snafu(display("failed to build label"))]
+    BuildLabel { source: LabelError },
+}
+
+pub struct ServiceConfig {
+    pub name: String,
+    pub internal_traffic_policy: String,
+}
+
+pub fn build_discoverable_services(
+    opa: &v1alpha1::OpaCluster,
+    resolved_product_image: &ResolvedProductImage,
+    service_configs: Vec<ServiceConfig>,
+) -> Result<Vec<Service>> {
+    let mut services = vec![];
+
+    // discoverable role services
+    for sc in service_configs {
+        let service_name = sc.name;
+        services.push(build_server_role_service(
+            opa,
+            resolved_product_image,
+            &service_name,
+            Some(sc.internal_traffic_policy.to_string()),
+        )?);
+    }
+
+    Ok(services)
+}
+
+fn build_server_role_service(
+    opa: &v1alpha1::OpaCluster,
+    resolved_product_image: &ResolvedProductImage,
+    service_name: &str,
+    internal_traffic_policy: Option<String>,
+) -> Result<Service> {
+    let role_name = v1alpha1::OpaRole::Server.to_string();
+
+    let metadata = ObjectMetaBuilder::new()
+        .name_and_namespace(opa)
+        .name(service_name)
+        .ownerreference_from_resource(opa, None, Some(true))
+        .context(ObjectMissingMetadataForOwnerRefSnafu {
+            opa: ObjectRef::from_obj(opa),
+        })?
+        .with_recommended_labels(build_recommended_labels(
+            opa,
+            &resolved_product_image.app_version_label,
+            &role_name,
+            "global",
+        ))
+        .context(ObjectMetaSnafu)?
+        .build();
+
+    let service_selector_labels =
+        Labels::role_selector(opa, APP_NAME, &role_name).context(BuildLabelSnafu)?;
+
+    let service_spec = ServiceSpec {
+        type_: Some(opa.spec.cluster_config.listener_class.k8s_service_type()),
+        ports: Some(vec![ServicePort {
+            name: Some(APP_PORT_NAME.to_string()),
+            port: APP_PORT.into(),
+            protocol: Some("TCP".to_string()),
+            ..ServicePort::default()
+        }]),
+        selector: Some(service_selector_labels.into()),
+        internal_traffic_policy,
+        ..ServiceSpec::default()
+    };
+
+    Ok(Service {
+        metadata,
+        spec: Some(service_spec),
+        status: None,
+    })
+}
+
+/// The rolegroup [`Service`] is a headless service that allows direct access to the instances of a certain rolegroup
+///
+/// This is mostly useful for internal communication between peers, or for clients that perform client-side load balancing.
+pub fn build_rolegroup_service(
+    opa: &v1alpha1::OpaCluster,
+    resolved_product_image: &ResolvedProductImage,
+    rolegroup: &RoleGroupRef<v1alpha1::OpaCluster>,
+) -> Result<Service> {
+    let prometheus_label =
+        Label::try_from(("prometheus.io/scrape", "true")).context(BuildLabelSnafu)?;
+
+    let metadata = ObjectMetaBuilder::new()
+        .name_and_namespace(opa)
+        .name(rolegroup.object_name())
+        .ownerreference_from_resource(opa, None, Some(true))
+        .context(ObjectMissingMetadataForOwnerRefSnafu {
+            opa: ObjectRef::from_obj(opa),
+        })?
+        .with_recommended_labels(build_recommended_labels(
+            opa,
+            &resolved_product_image.app_version_label,
+            &rolegroup.role,
+            &rolegroup.role_group,
+        ))
+        .context(ObjectMetaSnafu)?
+        .with_label(prometheus_label)
+        .build();
+
+    let service_selector_labels =
+        Labels::role_group_selector(opa, APP_NAME, &rolegroup.role, &rolegroup.role_group)
+            .context(BuildLabelSnafu)?;
+
+    let service_spec = ServiceSpec {
+        // Internal communication does not need to be exposed
+        type_: Some("ClusterIP".to_string()),
+        cluster_ip: Some("None".to_string()),
+        ports: Some(service_ports()),
+        selector: Some(service_selector_labels.into()),
+        publish_not_ready_addresses: Some(true),
+        ..ServiceSpec::default()
+    };
+
+    Ok(Service {
+        metadata,
+        spec: Some(service_spec),
+        status: None,
+    })
+}
+
+fn service_ports() -> Vec<ServicePort> {
+    vec![
+        ServicePort {
+            name: Some(APP_PORT_NAME.to_string()),
+            port: APP_PORT.into(),
+            protocol: Some("TCP".to_string()),
+            ..ServicePort::default()
+        },
+        ServicePort {
+            name: Some(METRICS_PORT_NAME.to_string()),
+            port: 9504, // Arbitrary port number, this is never actually used anywhere
+            protocol: Some("TCP".to_string()),
+            target_port: Some(IntOrString::String(APP_PORT_NAME.to_string())),
+            ..ServicePort::default()
+        },
+    ]
+}


### PR DESCRIPTION
# Description

This adds two role level services with `internalTrafficPolicy` as "Local" called `<cluster-name>-local`
and `internalTrafficPolicy` as "Cluster" called `<cluster-name>-cluster` and their discovery configmaps.

Users can now chose the round-robin service for heavy policy evaluations or (as is now) the local service for low latency requests.

The old  "Local" service `<cluster-name>` is kept as is to be non breaking and backwards compatibel.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
