### PR TITLE
chore(docs): Update getting-started script pre-25.3.0

### DIFF
--- a/docs/modules/opa/examples/getting_started/opa.yaml
+++ b/docs/modules/opa/examples/getting_started/opa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-opa
 spec:
   image:
-    productVersion: "1.0.0"
+    productVersion: "1.0.1"
   servers:
     roleGroups:
       default: {}

--- a/docs/modules/opa/examples/getting_started/opa.yaml.j2
+++ b/docs/modules/opa/examples/getting_started/opa.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-opa
 spec:
   image:
-    productVersion: "1.0.0"
+    productVersion: "1.0.1"
   servers:
     roleGroups:
       default: {}


### PR DESCRIPTION
# Check and Update Getting Started Script

Part of <https://github.com/stackabletech/issues/issues/697>

This PR bumps the following:

- `opa` to 1.0.1

```shell
# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm
```