### PR TITLE
fix: Use `json` file extension for log files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,12 @@ All notable changes to this project will be documented in this file.
     and is now set by `ROLLING_LOGS` (or via `--rolling-logs <DIRECTORY>`).
   - Replace stackable-operator `print_startup_string` with `tracing::info!` with fields.
 
+### Fixed
+
+- Use `json` file extension for log files ([#709]).
+
 [#703]: https://github.com/stackabletech/opa-operator/pull/703
+[#709]: https://github.com/stackabletech/opa-operator/pull/709
 
 ## [25.3.0] - 2025-03-21
 

--- a/rust/bundle-builder/src/main.rs
+++ b/rust/bundle-builder/src/main.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<(), StartupError> {
                     Settings::builder()
                         .with_environment_variable(ENV_VAR_CONSOLE_LOG)
                         .with_default_level(LevelFilter::INFO)
-                        .file_log_settings_builder(log_directory, "tracing-rs.log")
+                        .file_log_settings_builder(log_directory, "tracing-rs.json")
                         .with_rotation_period(rotation_period)
                         .build()
                 }),

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> anyhow::Result<()> {
                     Settings::builder()
                         .with_environment_variable(ENV_VAR_CONSOLE_LOG)
                         .with_default_level(LevelFilter::INFO)
-                        .file_log_settings_builder(log_directory, "tracing-rs.log")
+                        .file_log_settings_builder(log_directory, "tracing-rs.json")
                         .with_rotation_period(rotation_period)
                         .build()
                 }))

--- a/rust/user-info-fetcher/src/main.rs
+++ b/rust/user-info-fetcher/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<(), StartupError> {
                     Settings::builder()
                         .with_environment_variable(ENV_VAR_CONSOLE_LOG)
                         .with_default_level(LevelFilter::INFO)
-                        .file_log_settings_builder(log_directory, "tracing-rs.log")
+                        .file_log_settings_builder(log_directory, "tracing-rs.json")
                         .with_rotation_period(rotation_period)
                         .build()
                 }),


### PR DESCRIPTION
This was accidentally broken by work done in https://github.com/stackabletech/issues/issues/639 but before https://github.com/stackabletech/operator-rs/pull/1001 could be rolled out (which does use the correct file extension).

### Testing

```
--- PASS: kuttl (67.73s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_opa-1.0.1_openshift-false (67.72s)
PASS
```