### PR TITLE
chore: update to oci references

### DIFF
--- a/tests/templates/kuttl/ad-user-info/20-install-test-regorule.yaml
+++ b/tests/templates/kuttl/ad-user-info/20-install-test-regorule.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: test-regorule
-        image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+        image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
         stdin: true
         tty: true
         resources:


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/infrastructure/issues/142
Repository references were already updated for this repo with changelog entry already present, new old docker.stackable.tech reference was added after, this PR fixes that.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
