### PR TITLE
chore: Remove hardcoded uid and gid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ All notable changes to this project will be documented in this file.
     of having the operator write it to the vector config ([#707]).
 - test: Bump to Vector 0.46.1 ([#721]).
 - Use versioned common structs ([#727]).
+- BREAKING: Previously this operator would hardcode the UID and GID of the Pods being created to 1000/0, this has changed now ([#732])
+  - The `runAsUser` and `runAsGroup` fields will not be set anymore by the operator
+  - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
+  - This is marked as breaking because tools and policies might exist, which require these fields to be set
 
 ### Fixed
 
@@ -55,6 +59,7 @@ All notable changes to this project will be documented in this file.
 [#721]: https://github.com/stackabletech/opa-operator/pull/721
 [#723]: https://github.com/stackabletech/opa-operator/pull/723
 [#727]: https://github.com/stackabletech/opa-operator/pull/727
+[#732]: https://github.com/stackabletech/opa-operator/pull/732
 
 ## [25.3.0] - 2025-03-21
 

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -927,13 +927,7 @@ fn build_server_rolegroup_daemonset(
         )
         .context(AddVolumeSnafu)?
         .service_account_name(service_account.name_any())
-        .security_context(
-            PodSecurityContextBuilder::new()
-                .run_as_user(1000)
-                .run_as_group(0)
-                .fs_group(1000)
-                .build(),
-        );
+        .security_context(PodSecurityContextBuilder::new().fs_group(1000).build());
 
     if let Some(user_info) = &opa.spec.cluster_config.user_info {
         let mut cb_user_info_fetcher =


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/651

Remove hardcoded uid and gid, they'll default to the ones from the docker images now.
For 25.7 that means they might change from 1000/0
See https://github.com/stackabletech/docker-images/pull/916 for details

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Integration tests passed (for non trivial changes)

### Reviewer

- [ ] Changelog updated

### Acceptance

- [ ] Proper release label has been added
