### PR TITLE
tests: increase DaemonSet assert timeouts

### DIFF
--- a/tests/templates/kuttl/cluster-operation/10-assert.yaml
+++ b/tests/templates/kuttl/cluster-operation/10-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 600
 commands:
-  - script: kubectl -n $NAMESPACE rollout status daemonset test-opa-server-default --timeout 301s
-  - script: kubectl -n $NAMESPACE wait --for=condition=available opaclusters.opa.stackable.tech/test-opa --timeout 301s
+  - script: kubectl -n $NAMESPACE rollout status daemonset test-opa-server-default --timeout 600s
+  - script: kubectl -n $NAMESPACE wait --for=condition=available opaclusters.opa.stackable.tech/test-opa --timeout 600s

--- a/tests/templates/kuttl/logging/03-assert.yaml
+++ b/tests/templates/kuttl/logging/03-assert.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 600
 commands:
-  - script: kubectl -n $NAMESPACE rollout status daemonset test-opa-server-automatic-log-config --timeout 301s
+  - script: kubectl -n $NAMESPACE rollout status daemonset test-opa-server-automatic-log-config --timeout 600s

--- a/tests/templates/kuttl/resources/10-assert.yaml.j2
+++ b/tests/templates/kuttl/resources/10-assert.yaml.j2
@@ -3,8 +3,8 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 600
 commands:
-  - script: kubectl -n $NAMESPACE rollout status daemonset opa-server-resources-from-role --timeout 301s
-  - script: kubectl -n $NAMESPACE rollout status daemonset opa-server-resources-from-role-group --timeout 301s
+  - script: kubectl -n $NAMESPACE rollout status daemonset opa-server-resources-from-role --timeout 600s
+  - script: kubectl -n $NAMESPACE rollout status daemonset opa-server-resources-from-role-group --timeout 600s
 ---
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
## Description

Sometimes it takes longer than 5 minutes for all the OPA pods to be ready in our weekly tests.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
