### PR TITLE
fix: Add RBAC permission to patch events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ All notable changes to this project will be documented in this file.
   - The default Kubernetes cluster domain name is now fetched from the kubelet API unless explicitly configured.
   - This requires operators to have the RBAC permission to get nodes/proxy in the apiGroup "". The helm-chart takes care of this.
   - The CLI argument `--kubernetes-node-name` or env variable `KUBERNETES_NODE_NAME` needs to be set. The helm-chart takes care of this.
+- The operator helm-chart now grants RBAC `patch` permissions on `events.k8s.io/events`,
+  so events can be aggregated (e.g. "error happened 10 times over the last 5 minutes") ([#745]).
 
 ### Fixed
 
@@ -74,6 +76,7 @@ All notable changes to this project will be documented in this file.
 [#737]: https://github.com/stackabletech/opa-operator/pull/737
 [#743]: https://github.com/stackabletech/opa-operator/pull/743
 [#744]: https://github.com/stackabletech/opa-operator/pull/744
+[#745]: https://github.com/stackabletech/opa-operator/pull/745
 
 ## [25.3.0] - 2025-03-21
 

--- a/deploy/helm/opa-operator/templates/roles.yaml
+++ b/deploy/helm/opa-operator/templates/roles.yaml
@@ -82,7 +82,6 @@ rules:
       - events.k8s.io
     resources:
       - events
-      - patch
     verbs:
       - create
       - patch
@@ -132,6 +131,7 @@ rules:
       - events.k8s.io
     resources:
       - events
+      - patch
     verbs:
       - create
 {{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}

--- a/deploy/helm/opa-operator/templates/roles.yaml
+++ b/deploy/helm/opa-operator/templates/roles.yaml
@@ -131,7 +131,6 @@ rules:
       - events.k8s.io
     resources:
       - events
-      - patch
     verbs:
       - create
       - patch

--- a/deploy/helm/opa-operator/templates/roles.yaml
+++ b/deploy/helm/opa-operator/templates/roles.yaml
@@ -134,6 +134,7 @@ rules:
       - patch
     verbs:
       - create
+      - patch
 {{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
   - apiGroups:
       - security.openshift.io


### PR DESCRIPTION
Needed since https://github.com/stackabletech/operator-rs/pull/938

Not 100% sure why the product needs this, but it was this way before.
Also, fix a wrongly placed "patch"