### PR TITLE
chore: Mark user-info-fetcher as non-experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - BREAKING: The per-rolegroup services now only serves the HTTP port and has a `-headless` suffix to better indicate their
   purpose and to be consistent with other operators ([#748]).
 - BREAKING: The per-role server service is now prefixed with `-server` to be consistent with other operators ([#748]).
+- The User info fetcher is no longer an experimental feature ([#XXX]).
 
 [#748]: https://github.com/stackabletech/opa-operator/pull/748
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ All notable changes to this project will be documented in this file.
 - BREAKING: The per-rolegroup services now only serves the HTTP port and has a `-headless` suffix to better indicate their
   purpose and to be consistent with other operators ([#748]).
 - BREAKING: The per-role server service is now prefixed with `-server` to be consistent with other operators ([#748]).
-- The User info fetcher is no longer an experimental feature ([#XXX]).
+- The User info fetcher is no longer an experimental feature ([#752]).
 
 [#748]: https://github.com/stackabletech/opa-operator/pull/748
+[#752]: https://github.com/stackabletech/opa-operator/pull/752
 
 ## [25.7.0] - 2025-07-23
 

--- a/docs/modules/opa/pages/usage-guide/user-info-fetcher.adoc
+++ b/docs/modules/opa/pages/usage-guide/user-info-fetcher.adoc
@@ -1,7 +1,5 @@
 = User info fetcher
-:description: Experimental User Info Fetcher for OPA retrieves data from backends like Keycloak. Integrate extra user details into Rego rules for enhanced policy management.
-
-WARNING: This feature is experimental, and subject to change.
+:description: User Info Fetcher for OPA retrieves data from backends like Keycloak. Integrate extra user details into Rego rules for enhanced policy management.
 
 The _User info fetcher_ allows for additional information to be obtained from the configured backend (for example, Keycloak).
 You can then write Rego rules for OpenPolicyAgent which make an HTTP request to the User info fetcher and make use of the additional information returned for the username or user id.


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/opa-operator/issues/751
Grepped the repo for `experimental`

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
