### PR TITLE
fix: Add ENV to product config machinery to fix env overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed `envOverrides` which was ignored due to not being added to the product config machinery ([#754]).
+- Fixed `envOverrides` not getting applied due to not being added to the product config machinery ([#754]).
 
 [#748]: https://github.com/stackabletech/opa-operator/pull/748
 [#752]: https://github.com/stackabletech/opa-operator/pull/752

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ All notable changes to this project will be documented in this file.
 - BREAKING: The per-role server service is now prefixed with `-server` to be consistent with other operators ([#748]).
 - The User info fetcher is no longer an experimental feature ([#752]).
 
+### Fixed
+
+- Fixed `envOverrides` which was ignored due to not being added to the product config machinery ([#754]).
+
 [#748]: https://github.com/stackabletech/opa-operator/pull/748
 [#752]: https://github.com/stackabletech/opa-operator/pull/752
+[#754]: https://github.com/stackabletech/opa-operator/pull/754
 
 ## [25.7.0] - 2025-07-23
 

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -449,6 +449,7 @@ pub async fn reconcile_opa(
                 (
                     vec![
                         PropertyNameKind::File(CONFIG_FILE.to_string()),
+                        PropertyNameKind::Env,
                         PropertyNameKind::Cli,
                     ],
                     opa.spec.servers.clone(),

--- a/tests/templates/kuttl/smoke/10-install-opa.yaml.j2
+++ b/tests/templates/kuttl/smoke/10-install-opa.yaml.j2
@@ -38,5 +38,9 @@ spec:
     config:
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
+    envOverrides:
+      SERVER_ROLE_LEVEL_ENV_VAR: "SERVER_ROLE_LEVEL_ENV_VAR"    
     roleGroups:
-      default: {}
+      default:
+        envOverrides:
+          SERVER_ROLE_GROUP_LEVEL_ENV_VAR: "SERVER_ROLE_GROUP_LEVEL_ENV_VAR"

--- a/tests/templates/kuttl/smoke/10-install-opa.yaml.j2
+++ b/tests/templates/kuttl/smoke/10-install-opa.yaml.j2
@@ -39,7 +39,7 @@ spec:
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     envOverrides:
-      SERVER_ROLE_LEVEL_ENV_VAR: "SERVER_ROLE_LEVEL_ENV_VAR"    
+      SERVER_ROLE_LEVEL_ENV_VAR: "SERVER_ROLE_LEVEL_ENV_VAR"
     roleGroups:
       default:
         envOverrides:

--- a/tests/templates/kuttl/smoke/32-assert.yaml
+++ b/tests/templates/kuttl/smoke/32-assert.yaml
@@ -4,4 +4,7 @@ kind: TestAssert
 metadata:
   name: test-env-overrides
 commands:
+  # Role level env var
+  - script: kubectl exec -n $NAMESPACE -c opa svc/test-opa-server -- env | grep SERVER_ROLE_LEVEL_ENV_VAR
+  # RoleGroup level env var
   - script: kubectl exec -n $NAMESPACE -c opa svc/test-opa-server -- env | grep SERVER_ROLE_GROUP_LEVEL_ENV_VAR

--- a/tests/templates/kuttl/smoke/32-assert.yaml
+++ b/tests/templates/kuttl/smoke/32-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: test-env-overrides
+commands:
+  - script: kubectl exec -n $NAMESPACE -c opa svc/test-opa-server -- env | grep SERVER_ROLE_GROUP_LEVEL_ENV_VAR


### PR DESCRIPTION
## Description

- env variables and therefore env_overrides were not considered from product config machinery

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [x] Code contains useful comments
- [x] Code contains useful logging statements
- [x] (Integration-)Test cases added
- [x] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
