### PR TITLE
fix(docs): Update getting-started script pre-25.11.0

### DIFF
--- a/docs/modules/opa/examples/getting_started/getting_started.sh
+++ b/docs/modules/opa/examples/getting_started/getting_started.sh
@@ -58,7 +58,7 @@ sleep 21
 
 echo "Starting port-forwarding of port 8081"
 # tag::port-forwarding[]
-kubectl port-forward svc/simple-opa 8081 > /dev/null 2>&1 &
+kubectl port-forward svc/simple-opa-server 8081 > /dev/null 2>&1 &
 # end::port-forwarding[]
 PORT_FORWARD_PID=$!
 # shellcheck disable=SC2064

--- a/docs/modules/opa/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/opa/examples/getting_started/getting_started.sh.j2
@@ -58,7 +58,7 @@ sleep 21
 
 echo "Starting port-forwarding of port 8081"
 # tag::port-forwarding[]
-kubectl port-forward svc/simple-opa 8081 > /dev/null 2>&1 &
+kubectl port-forward svc/simple-opa-server 8081 > /dev/null 2>&1 &
 # end::port-forwarding[]
 PORT_FORWARD_PID=$!
 # shellcheck disable=SC2064


### PR DESCRIPTION
## Check and Update Getting Started Script

<!--
    Make sure to update the link in 'issues/.github/ISSUE_TEMPLATE/pre-release-getting-started-scripts.md'
    when you rename this file.
-->

<!--
    Replace 'TRACKING_ISSUE' with the applicable release tracking issue number.
-->

Part of https://github.com/stackabletech/issues/issues/791

> [!NOTE]
> During a Stackable release we need to check (and optionally update) the
> getting-started scripts to ensure they still work after product and operator
> updates.

```shell
# Some of the scripts are in a code/ subdirectory
# pushd docs/modules/superset/examples/getting_started
# pushd docs/modules/superset/examples/getting_started/code
pushd $(fd -td getting_started | grep examples); cd code 2>/dev/null || true

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm

popd
```
