### PR TITLE
fix(docs): Update getting-started script pre-26.3.0

### DIFF
--- a/docs/modules/opa/examples/getting_started/getting_started.sh
+++ b/docs/modules/opa/examples/getting_started/getting_started.sh
@@ -17,6 +17,9 @@ then
   exit 1
 fi
 
+echo "Waiting for node(s) to be ready..."
+kubectl wait node --all --for=condition=Ready --timeout=120s
+
 case "$1" in
 "helm")
 echo "Installing operators with Helm"
@@ -35,6 +38,9 @@ echo "Need to provide 'helm' or 'stackablectl' as an argument for which installa
 exit 1
 ;;
 esac
+
+# TODO: Remove once https://github.com/stackabletech/issues/issues/828 has been implemented (see that issue for details).
+until kubectl get crd opaclusters.opa.stackable.tech >/dev/null 2>&1; do echo "Waiting for CRDs to be installed" && sleep 1; done
 
 echo "Creating OPA cluster"
 # tag::apply-opa-cluster[]

--- a/docs/modules/opa/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/opa/examples/getting_started/getting_started.sh.j2
@@ -17,6 +17,9 @@ then
   exit 1
 fi
 
+echo "Waiting for node(s) to be ready..."
+kubectl wait node --all --for=condition=Ready --timeout=120s
+
 case "$1" in
 "helm")
 echo "Installing operators with Helm"
@@ -35,6 +38,9 @@ echo "Need to provide 'helm' or 'stackablectl' as an argument for which installa
 exit 1
 ;;
 esac
+
+# TODO: Remove once https://github.com/stackabletech/issues/issues/828 has been implemented (see that issue for details).
+until kubectl get crd opaclusters.opa.stackable.tech >/dev/null 2>&1; do echo "Waiting for CRDs to be installed" && sleep 1; done
 
 echo "Creating OPA cluster"
 # tag::apply-opa-cluster[]

--- a/docs/modules/opa/examples/getting_started/opa.yaml.j2
+++ b/docs/modules/opa/examples/getting_started/opa.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-opa
 spec:
   image:
-    productVersion: "1.8.0"
+    productVersion: "1.12.3"
   servers:
     roleGroups:
       default: {}


### PR DESCRIPTION
## Check and Update Getting Started Script

<!--
    Make sure to update the link in 'issues/.github/ISSUE_TEMPLATE/pre-release-getting-started-scripts.md'
    when you rename this file.
-->

<!--
    Replace 'TRACKING_ISSUE' with the applicable release tracking issue number.
-->

Part of <https://github.com/stackabletech/issues/issues/826>

This getting-started script was technically fine as is (it ran through without any issues), but I still opted to include both waiting conditions, because it generally a good thing to do going forward.
