### PR TITLE
feat: daemonset maxsurge to prevent unavailability on config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Set `maxSurge=1` and `maxUnavailable=0` on the OPA DaemonSet rolling update strategy to eliminate
+  availability gaps during rolling updates ([#819]).
+
+[#819]: https://github.com/stackabletech/opa-operator/pull/819
+
 ## [26.3.0] - 2026-03-16
 
 ## [26.3.0-rc1] - 2026-03-16

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -34,7 +34,9 @@ use stackable_operator::{
     k8s_openapi::{
         DeepMerge,
         api::{
-            apps::v1::{DaemonSet, DaemonSetSpec},
+            apps::v1::{
+                DaemonSet, DaemonSetSpec, DaemonSetUpdateStrategy, RollingUpdateDaemonSet,
+            },
             core::v1::{
                 ConfigMap, EmptyDirVolumeSource, EnvVar, EnvVarSource, HTTPGetAction,
                 ObjectFieldSelector, Probe, SecretVolumeSource, ServiceAccount,
@@ -1153,6 +1155,13 @@ fn build_server_rolegroup_daemonset(
             ..LabelSelector::default()
         },
         template: pod_template,
+        update_strategy: Some(DaemonSetUpdateStrategy {
+            type_: Some("RollingUpdate".to_string()),
+            rolling_update: Some(RollingUpdateDaemonSet {
+                max_surge: Some(IntOrString::Int(1)),
+                max_unavailable: Some(IntOrString::Int(0)),
+            }),
+        }),
         ..DaemonSetSpec::default()
     };
 

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -34,9 +34,7 @@ use stackable_operator::{
     k8s_openapi::{
         DeepMerge,
         api::{
-            apps::v1::{
-                DaemonSet, DaemonSetSpec, DaemonSetUpdateStrategy, RollingUpdateDaemonSet,
-            },
+            apps::v1::{DaemonSet, DaemonSetSpec, DaemonSetUpdateStrategy, RollingUpdateDaemonSet},
             core::v1::{
                 ConfigMap, EmptyDirVolumeSource, EnvVar, EnvVarSource, HTTPGetAction,
                 ObjectFieldSelector, Probe, SecretVolumeSource, ServiceAccount,

--- a/rust/operator-binary/src/service.rs
+++ b/rust/operator-binary/src/service.rs
@@ -63,6 +63,12 @@ pub(crate) fn build_server_role_service(
         type_: Some(opa.spec.cluster_config.listener_class.k8s_service_type()),
         ports: Some(data_service_ports(opa.spec.cluster_config.tls_enabled())),
         selector: Some(service_selector_labels.into()),
+        // This ensures that products (e.g. Trino) on a node always talk to the OPA pod on the
+        // same node, avoiding cross-node latency. The downside is that if the local OPA pod is
+        // unavailable, requests fail instead of falling back to another node.
+        // TODO: Once our minimum supported Kubernetes version is 1.35, use
+        // `trafficDistribution: PreferSameNode` instead, which prefers the local node but
+        // gracefully falls back to other nodes if the local pod is unavailable.
         internal_traffic_policy: Some("Local".to_string()),
         ..ServiceSpec::default()
     };

--- a/tests/templates/kuttl/smoke/10-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/10-assert.yaml.j2
@@ -9,6 +9,11 @@ kind: DaemonSet
 metadata:
   name: test-opa-server-default
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     spec:
       containers:


### PR DESCRIPTION
## Description

Solves the problem reported in https://github.com/stackabletech/opa-operator/issues/817

Set maxSurge=1 and maxUnavailable=0 on the OPA `DaemonSet` so that during rolling updates, the new OPA pod is created and becomes ready before the old pod is terminated. This eliminates the availability gap that causes errors in products like Trino when OPA config changes trigger a `DaemonSet` restart.

DaemonSet `maxSurge` graduated to GA in Kubernetes 1.25, our current minimum supported Kubernetes version is 1.31.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [x] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
