### PR TITLE
fix: Fix broken link to OpaCluster CRD docs

### DIFF
--- a/docs/modules/opa/pages/index.adoc
+++ b/docs/modules/opa/pages/index.adoc
@@ -4,7 +4,7 @@
 :opa: https://www.openpolicyagent.org/
 :github: https://github.com/stackabletech/opa-operator/
 :crd: {crd-docs-base-url}/opa-operator/{crd-docs-version}/
-:crd-opacluster: {crd-docs}/opa.stackable.tech/opacluster/v1alpha1/
+:crd-opacluster: {crd-docs}/opa.stackable.tech/opacluster/v1alpha2/
 :feature-tracker: https://features.stackable.tech/unified
 :rego: https://www.openpolicyagent.org/docs/latest/policy-language/
 


### PR DESCRIPTION
## Description

Fixes the broken link to the OpaCluster CRD docs. Needs to be backported to `release-26.3` also.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
