### PR TITLE
tests: Fix test assert to be independent of cluster size

### DIFF
--- a/tests/templates/kuttl/config-overrides/10-assert.yaml.j2
+++ b/tests/templates/kuttl/config-overrides/10-assert.yaml.j2
@@ -60,4 +60,5 @@ kind: DaemonSet
 metadata:
   name: test-opa-server-default
 status:
-  numberReady: 1
+  # This has to be independent of the number of nodes on the cluster
+  numberMisscheduled: 0


### PR DESCRIPTION
Fix test assert.

:green_circle: https://testing.stackable.tech/job/opa-operator-it-custom/46/
:green_circle: https://testing.stackable.tech/job/opa-operator-it-custom/47/

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
