### PR TITLE
chore: Upgrade to stackable-operator 0.116.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ All notable changes to this project will be documented in this file.
 - The RBAC ServiceAccount and RoleBinding are now built with the operator-rs `v2::rbac`
   functions and carry the full set of recommended labels ([#861]).
 - All product containers now run with `securityContext.runAsNonRoot` set to `true` to improve security ([#871]).
+- Bump `stackable-operator` to 0.116.0 ([#867], [#880]).
+- Environment variable overrides (`envOverrides`) are now applied after all environment
+  variables set by the operator. In particular, `CONTAINERDEBUG_LOG_DIRECTORY` can now be
+  overridden, whereas previously the operator's value always took precedence ([#880]).
+- BREAKING: Remove the `app.kubernetes.io/component` and `app.kubernetes.io/role-group` labels
+  from the resources they don't apply to (previously set to `none` or a placeholder value):
+  the role-level Service (`<cluster>-server`) and the discovery ConfigMap lose
+  `app.kubernetes.io/role-group`, and the RBAC ServiceAccount and RoleBinding lose both labels (previously `none`). Anything selecting on these label values must be adjusted. All resources can be updated in place; no manual
+  deletion is required ([#880]).
 
 ### Fixed
 
@@ -26,6 +35,7 @@ All notable changes to this project will be documented in this file.
 [#867]: https://github.com/stackabletech/opa-operator/pull/867
 [#871]: https://github.com/stackabletech/opa-operator/pull/871
 [#872]: https://github.com/stackabletech/opa-operator/pull/872
+[#880]: https://github.com/stackabletech/opa-operator/pull/880
 
 ## [26.7.0] - 2026-07-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -207,9 +207,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -386,9 +386,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -780,7 +780,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1075,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flagset"
@@ -1139,9 +1139,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1154,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1164,15 +1164,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1181,38 +1181,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1326,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1414,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1576,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1589,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1603,16 +1603,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1623,15 +1624,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1809,7 +1810,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -1858,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1877,7 +1878,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1890,7 +1891,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1919,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "k8s-version"
 version = "0.1.3"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "darling 0.24.0",
  "regex",
@@ -2000,7 +2001,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tower",
@@ -2024,7 +2025,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2062,7 +2063,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2105,7 +2106,7 @@ dependencies = [
  "nom",
  "percent-encoding",
  "ring",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-native-tls",
  "tokio-stream",
@@ -2189,9 +2190,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -2264,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -2348,9 +2349,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -2450,7 +2451,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -2492,7 +2493,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tonic",
  "tonic-types",
@@ -2530,7 +2531,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
 ]
@@ -2612,9 +2613,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2622,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2632,9 +2633,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2645,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -2701,15 +2702,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2722,9 +2723,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -2911,18 +2912,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3139,9 +3140,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3577,7 +3578,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stackable-certs"
 version = "0.4.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "const-oid",
  "ecdsa",
@@ -3677,8 +3678,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.115.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+version = "0.116.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "base64 0.23.1",
  "clap",
@@ -3722,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "darling 0.24.0",
  "proc-macro2",
@@ -3733,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.1.2"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "jiff",
  "k8s-openapi",
@@ -3750,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "stackable-telemetry"
 version = "0.6.5"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "axum",
  "clap",
@@ -3774,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned"
 version = "0.11.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "kube",
  "schemars",
@@ -3788,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned-macros"
 version = "0.11.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "convert_case",
  "convert_case_extras",
@@ -3806,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "stackable-webhook"
 version = "0.9.2"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3989,11 +3990,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4009,9 +4010,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4059,9 +4060,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4300,7 +4301,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tracing-subscriber",
 ]
@@ -4465,9 +4466,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4528,9 +4529,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4541,9 +4542,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4551,9 +4552,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4561,9 +4562,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4574,18 +4575,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4891,9 +4892,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "x509-cert"
@@ -5011,9 +5012,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5022,9 +5023,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5033,13 +5034,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -567,9 +567,9 @@ rec {
       };
       "async-trait" = rec {
         crateName = "async-trait";
-        version = "0.1.91";
+        version = "0.1.92";
         edition = "2021";
-        sha256 = "1v3cm8mzg66037wm392p1vsdx0lq8bid6y2ivr7z03lpfx0xqdmf";
+        sha256 = "0rqn5iga1hlv2lm8xzav1zhar46jb4dvx89i6kfv93kb53maxxl2";
         procMacro = true;
         libName = "async_trait";
         authors = [
@@ -619,10 +619,10 @@ rec {
       };
       "aws-lc-rs" = rec {
         crateName = "aws-lc-rs";
-        version = "1.17.3";
+        version = "1.18.0";
         edition = "2021";
-        links = "aws_lc_rs_1_17_3_sys";
-        sha256 = "1wbj1n78iqsf38xd2q93isjkb1iyaf7akm3wrji8ri6s33dbbg80";
+        links = "aws_lc_rs_1_18_0_sys";
+        sha256 = "17nx79a6wyx6xx5kj0f09vr0wh1q4agwjxqy6w6swfwwhz62sayf";
         libName = "aws_lc_rs";
         authors = [
           "AWS-LibCrypto"
@@ -655,10 +655,10 @@ rec {
       };
       "aws-lc-sys" = rec {
         crateName = "aws-lc-sys";
-        version = "0.43.0";
+        version = "0.44.0";
         edition = "2021";
-        links = "aws_lc_0_43_0";
-        sha256 = "0k12q9axgpzhqj5q5ics2m302fnbr4pp4pipi9kn5zknril32423";
+        links = "aws_lc_0_44_0";
+        sha256 = "10vlwayxyylnn4vs57xs0iy0rp76k50v7zbabkh78cdvx1xsx7zh";
         build = "builder/main.rs";
         libName = "aws_lc_sys";
         authors = [
@@ -1242,12 +1242,9 @@ rec {
       };
       "cc" = rec {
         crateName = "cc";
-        version = "1.4.0";
-        edition = "2018";
-        sha256 = "1fc26n76n7gr37m2q0xw5l8jpn4sd33hvyppmwhv6v4fcyxq3pas";
-        authors = [
-          "Alex Crichton <alex@alexcrichton.com>"
-        ];
+        version = "1.4.3";
+        edition = "2021";
+        sha256 = "0v9b5arr047vbihfbh3fmbd3aj9vf1i7dbdgfpvlwzynpjvr35ah";
         dependencies = [
           {
             name = "find-msvc-tools";
@@ -1272,7 +1269,7 @@ rec {
           }
         ];
         features = {
-          "parallel" = [ "dep:libc" "dep:jobserver" ];
+          "parallel" = [ "dep:jobserver" "dep:libc" ];
         };
         resolvedDefaultFeatures = [ "parallel" ];
       };
@@ -2409,7 +2406,7 @@ rec {
         dependencies = [
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
         ];
         features = {
@@ -3331,9 +3328,9 @@ rec {
       };
       "find-msvc-tools" = rec {
         crateName = "find-msvc-tools";
-        version = "0.1.9";
-        edition = "2018";
-        sha256 = "10nmi0qdskq6l7zwxw5g56xny7hb624iki1c39d907qmfh3vrbjv";
+        version = "0.1.11";
+        edition = "2021";
+        sha256 = "145qpfb9r4ml2klr8v4byvrkikp61qyiks9n69b8z0vbscbb0pfl";
         libName = "find_msvc_tools";
 
       };
@@ -3487,9 +3484,9 @@ rec {
       };
       "futures" = rec {
         crateName = "futures";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "066j5aqz8an05xh4hn5ljdnjn80z3g335v4grx4gaifr57wg3358";
+        sha256 = "18yhwmbdalhz2z9i1vm10hy2v0cfm82dkgcb6vr2msxazfix4ccs";
         dependencies = [
           {
             name = "futures-channel";
@@ -3549,9 +3546,9 @@ rec {
       };
       "futures-channel" = rec {
         crateName = "futures-channel";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "1bn5hlhfkl1sgypmiachaqcgwmr6wmjal7dyhfyb1zkazvs90996";
+        sha256 = "1i4kwcanpaphn1ax62ci3nx176kglxqx0gnhzqpqdr1rkpbf7ydi";
         libName = "futures_channel";
         dependencies = [
           {
@@ -3577,9 +3574,9 @@ rec {
       };
       "futures-core" = rec {
         crateName = "futures-core";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "1iqdbvcdlplfr2g43h7xrfkv2sg5p1a26x8acz1xgxl07i3hrm9c";
+        sha256 = "0pjgv4fx0np6hrs5sz5a2phabwv0z70yr51v03injbi44bjrkmlj";
         libName = "futures_core";
         features = {
           "default" = [ "std" ];
@@ -3590,9 +3587,9 @@ rec {
       };
       "futures-executor" = rec {
         crateName = "futures-executor";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "0n3lpkmcfrsnh40i4armn040gnqbpd257hz5qs46zipjr6f8fm37";
+        sha256 = "0cjl3y7jgg60wwb96ikxj23r6q91ylvx8v675yychv1w3b7lf6q3";
         libName = "futures_executor";
         dependencies = [
           {
@@ -3620,9 +3617,9 @@ rec {
       };
       "futures-io" = rec {
         crateName = "futures-io";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "0yjx13qdm9b2p4w00ddw85k6yccnnmqrlrrz8yfmi5jg7jmfqxs5";
+        sha256 = "1v9z6wj92ra18kpv0xig21hgpzrvcwmcr8fszyzh64yyay0zmh2k";
         libName = "futures_io";
         features = {
           "default" = [ "std" ];
@@ -3631,9 +3628,9 @@ rec {
       };
       "futures-macro" = rec {
         crateName = "futures-macro";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "02xiyd5y1nk9b805aympj4wq2czgvxnhcml9w9xkc665d3g3qv9d";
+        sha256 = "0i0czvcvsqq4hrccibq2f23004si5z34zjwdxfmqhlrmm15nbfcz";
         procMacro = true;
         libName = "futures_macro";
         dependencies = [
@@ -3647,7 +3644,7 @@ rec {
           }
           {
             name = "syn";
-            packageId = "syn 2.0.119";
+            packageId = "syn 3.0.3";
             features = [ "full" ];
           }
         ];
@@ -3655,9 +3652,9 @@ rec {
       };
       "futures-sink" = rec {
         crateName = "futures-sink";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "01z38z344hpryw84b6r0rbwcb669d8pyvl2szg10aqwx96n1hi73";
+        sha256 = "07cfvrgc3vxk6sw5g8a8dnrm1mzg6d5mwy08ywa1sgyhyxml4i0r";
         libName = "futures_sink";
         features = {
           "default" = [ "std" ];
@@ -3667,9 +3664,9 @@ rec {
       };
       "futures-task" = rec {
         crateName = "futures-task";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "02f1y1yvjg1cv998zkgl1706pi9y4fyc9045l1hlmyqyhclfscdj";
+        sha256 = "1zfilqs8nwlfqz4prk7ihvpp5avvzins87ibzlxzq5fhs7ipshfd";
         libName = "futures_task";
         features = {
           "default" = [ "std" ];
@@ -3679,9 +3676,9 @@ rec {
       };
       "futures-util" = rec {
         crateName = "futures-util";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "1anyg40j5www5l22r2jbn1birsafz4q1w9qmcjk4vqzwasi90ym7";
+        sha256 = "1g3r9ghzq7c2fh34lis43i72xavk9p84npgfwgb5vfpqcwjajl0d";
         libName = "futures_util";
         dependencies = [
           {
@@ -4157,9 +4154,9 @@ rec {
       };
       "h2" = rec {
         crateName = "h2";
-        version = "0.4.15";
+        version = "0.4.16";
         edition = "2021";
-        sha256 = "0mgilh1g8gydcchqi6acs5l6j0gwg5jwpa64sj4b3ncb9v497c3c";
+        sha256 = "09syqqhvh36b3rwyn8vjhiz597hfki1hcz3hwagb3cs1ifapmwx9";
         authors = [
           "Carl Lerche <me@carllerche.com>"
           "Sean McArthur <sean@seanmonstar.com>"
@@ -4413,9 +4410,9 @@ rec {
       };
       "http-body-util" = rec {
         crateName = "http-body-util";
-        version = "0.1.4";
+        version = "0.1.5";
         edition = "2018";
-        sha256 = "1wizkqx9a75x8v5lm7cawpammz8sfvd7cngnkp34wkcfl3b1zx79";
+        sha256 = "07773iilap808wjp6vywlq15zkgwnswqzrv270zxvg2z9biry5i3";
         libName = "http_body_util";
         authors = [
           "Carl Lerche <me@carllerche.com>"
@@ -4997,9 +4994,9 @@ rec {
       };
       "icu_collections" = rec {
         crateName = "icu_collections";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "070r7xd0pynm0hnc1v2jzlbxka6wf50f81wybf9xg0y82v6x3119";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "04x59h6vdq0cnpippim1nr471ivlsnnn470sj1d5v864h48d4s7s";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -5047,9 +5044,9 @@ rec {
       };
       "icu_locale_core" = rec {
         crateName = "icu_locale_core";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "0a9cmin5w1x3bg941dlmgszn33qgq428k7qiqn5did72ndi9n8cj";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "1sqdj16wwl7h9y6r7j394av4kpdb7zryz9h169ffwbm9imc2hvnm";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -5099,9 +5096,9 @@ rec {
       };
       "icu_normalizer" = rec {
         crateName = "icu_normalizer";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "1d7krxr0xpc4x9635k1100a24nh0nrc59n65j6yk6gbfkplmwvn5";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "0vv43ixk2wmbxrx7kl33cwkhx1wdyb1q3pa18qkyshan4dgwzy8j";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -5153,9 +5150,9 @@ rec {
       };
       "icu_normalizer_data" = rec {
         crateName = "icu_normalizer_data";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "0f5d5d5fhhr9937m2z6z38fzh6agf14z24kwlr6lyczafypf0fys";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "1811h0ppb7lwq1q2492p5x6lcmlwmhbmkf69fhyvzcz0scgdlqqm";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -5163,13 +5160,18 @@ rec {
       };
       "icu_properties" = rec {
         crateName = "icu_properties";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "1pkh3s837808cbwxvfagwc28cvwrz2d9h5rl02jwrhm51ryvdqxy";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "0j51hi8qgf0l6a7qzvnwsc61598w2fpnsklicld6ci9immva4z3y";
         authors = [
           "The ICU4X Project Developers"
         ];
         dependencies = [
+          {
+            name = "displaydoc";
+            packageId = "displaydoc";
+            usesDefaultFeatures = false;
+          }
           {
             name = "icu_collections";
             packageId = "icu_collections";
@@ -5211,6 +5213,7 @@ rec {
           "datagen" = [ "serde" "dep:databake" "zerovec/databake" "icu_collections/databake" "icu_locale_core/databake" "zerotrie/databake" "icu_provider/export" ];
           "default" = [ "compiled_data" ];
           "harfbuzz_traits" = [ "dep:harfbuzz-traits" ];
+          "log" = [ "dep:log" ];
           "serde" = [ "dep:serde" "icu_locale_core/serde" "zerovec/serde" "icu_collections/serde" "icu_provider/serde" "zerotrie/serde" ];
           "unicode_bidi" = [ "dep:unicode-bidi" ];
         };
@@ -5218,9 +5221,9 @@ rec {
       };
       "icu_properties_data" = rec {
         crateName = "icu_properties_data";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "052awny0qwkbcbpd5jg2cd7vl5ry26pq4hz1nfsgf10c3qhbnawf";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "1akw1gp5rcaiz377xzsnkx8f92qax4kh3lfn9y4rcjj6q4wg1475";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -5228,9 +5231,9 @@ rec {
       };
       "icu_provider" = rec {
         crateName = "icu_provider";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "08dl8pxbwr8zsz4c5vphqb7xw0hykkznwi4rw7bk6pwb3krlr70k";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "0a343jlrb7jlb20xv1airslzv63559wf38jihrx81bba39kyv9wj";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -5749,7 +5752,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "windows-link";
@@ -5867,9 +5870,9 @@ rec {
       };
       "js-sys" = rec {
         crateName = "js-sys";
-        version = "0.3.103";
+        version = "0.3.104";
         edition = "2021";
-        sha256 = "00lib0b6hqmw56r2hjp7xrv730qacslirbkdlhvmi39zvgy4pd2k";
+        sha256 = "0fjsgady7wbv7bbyy6c8qhrd93bnx11qbl83l1g7bb9a4601030f";
         libName = "js_sys";
         authors = [
           "The wasm-bindgen Developers"
@@ -5929,7 +5932,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
         ];
         devDependencies = [
@@ -5978,7 +5981,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
         ];
 
@@ -6076,8 +6079,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "k8s_version";
         authors = [
@@ -6406,7 +6409,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "tokio";
@@ -6572,7 +6575,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
         ];
         devDependencies = [
@@ -6724,7 +6727,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "tokio";
@@ -6869,7 +6872,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "tokio";
@@ -7126,9 +7129,9 @@ rec {
       };
       "litemap" = rec {
         crateName = "litemap";
-        version = "0.8.2";
+        version = "0.8.3";
         edition = "2021";
-        sha256 = "1w7628bc7wwcxc4n4s5kw0610xk06710nh2hn5kwwk2wa91z9nlj";
+        sha256 = "1bpgpj87560hmckh3875fbahpmfxbk4g8pzns84h3ykf3nfx3na7";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -7332,9 +7335,9 @@ rec {
       };
       "moka" = rec {
         crateName = "moka";
-        version = "0.12.15";
+        version = "0.12.16";
         edition = "2021";
-        sha256 = "0ijhgjfprcjkvrhgmm71m9gaph5lc9xjb3rwz4wyhbh42anjhwlm";
+        sha256 = "1f8r7pb5l7qp0i6k8id419gcc9bh6xa5b1c4qprwm8b7fn7g34s2";
         dependencies = [
           {
             name = "async-lock";
@@ -7621,9 +7624,9 @@ rec {
       };
       "num-integer" = rec {
         crateName = "num-integer";
-        version = "0.1.46";
+        version = "0.1.47";
         edition = "2018";
-        sha256 = "13w5g54a9184cqlbsq80rnxw4jj4s0d8wv75jsq5r2lms8gncsbr";
+        sha256 = "02z1p3azy6p10n99skrab4a6hhfd4amf2i9gm8sxqd1p9dfxkqkw";
         libName = "num_integer";
         authors = [
           "The Rust Project Developers"
@@ -7897,7 +7900,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
             optional = true;
             usesDefaultFeatures = false;
           }
@@ -8067,7 +8070,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
             usesDefaultFeatures = false;
           }
           {
@@ -8274,7 +8277,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
             usesDefaultFeatures = false;
           }
           {
@@ -8575,9 +8578,9 @@ rec {
       };
       "pest" = rec {
         crateName = "pest";
-        version = "2.8.8";
+        version = "2.9.0";
         edition = "2021";
-        sha256 = "18jhl2zpxvl6kikc0jgp7gi7i7cy9s634z5bnvx70w1whjz2ixvx";
+        sha256 = "1kwvhc5hyrfpxpmp0jw0wr891xyjs44mcs2wz68hrl54qw6ac1ss";
         authors = [
           "Dragoș Tiselice <dragostiselice@gmail.com>"
         ];
@@ -8604,9 +8607,9 @@ rec {
       };
       "pest_derive" = rec {
         crateName = "pest_derive";
-        version = "2.8.8";
+        version = "2.9.0";
         edition = "2021";
-        sha256 = "1zcijlfdf6sk2s6l1qnm3j7kj7d4ymqcial8w4p4dcr67gydcbcy";
+        sha256 = "13f8ihi8928s9mc13pcbhxy382kqc89h7i8d7s5mnif8lm23ga5k";
         procMacro = true;
         authors = [
           "Dragoș Tiselice <dragostiselice@gmail.com>"
@@ -8632,9 +8635,9 @@ rec {
       };
       "pest_generator" = rec {
         crateName = "pest_generator";
-        version = "2.8.8";
+        version = "2.9.0";
         edition = "2021";
-        sha256 = "1dkmk6r6bb2hh5wayymfmwd7mswwbyhw12dnx2lrdxdnrw2r4yka";
+        sha256 = "0jihcdnmdban4bqjd02r2wbb79nywj2nhwqyk95hvrixm98k9kg0";
         authors = [
           "Dragoș Tiselice <dragostiselice@gmail.com>"
         ];
@@ -8670,9 +8673,9 @@ rec {
       };
       "pest_meta" = rec {
         crateName = "pest_meta";
-        version = "2.8.8";
+        version = "2.9.0";
         edition = "2021";
-        sha256 = "0z7m54jc3nj3nxbbk4kyjfa06d8s24vhf6krzj2867nyq18x7aw5";
+        sha256 = "15jly0r7r4m15fhm3pg814h65j7dqnqq6k43rvgxfhg29443lkg0";
         authors = [
           "Dragoș Tiselice <dragostiselice@gmail.com>"
         ];
@@ -8803,9 +8806,9 @@ rec {
       };
       "pkg-config" = rec {
         crateName = "pkg-config";
-        version = "0.3.33";
-        edition = "2018";
-        sha256 = "17jnqmcbxsnwhg9gjf0nh6dj5k0x3hgwi3mb9krjnmfa9v435w8r";
+        version = "0.3.34";
+        edition = "2021";
+        sha256 = "0j05h08nzg0q8rf6lzw7nry0b7kn7x97vc9n4hwrl52fqzxn9d7n";
         libName = "pkg_config";
         authors = [
           "Alex Crichton <alex@alexcrichton.com>"
@@ -8814,9 +8817,9 @@ rec {
       };
       "portable-atomic" = rec {
         crateName = "portable-atomic";
-        version = "1.14.0";
+        version = "1.15.0";
         edition = "2018";
-        sha256 = "1hyfma9n2cs2ibazpfwrbv61zwg7cv86g0pr5yjkg07qgr4xa81x";
+        sha256 = "11csag858ndk5w4yz17h91vy53ynh67r2903gwwdn2cnilzbdj05";
         libName = "portable_atomic";
         features = {
           "critical-section" = [ "dep:critical-section" ];
@@ -8847,9 +8850,9 @@ rec {
       };
       "potential_utf" = rec {
         crateName = "potential_utf";
-        version = "0.1.5";
+        version = "0.1.6";
         edition = "2021";
-        sha256 = "0r0518fr32xbkgzqap509s3r60cr0iancsg9j1jgf37cyz7b20q1";
+        sha256 = "0qbndl2fpphq7mph41m11vaixs05xrh1s451wxlgap4fdnybjgnq";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -9381,9 +9384,9 @@ rec {
       };
       "ref-cast" = rec {
         crateName = "ref-cast";
-        version = "1.0.26";
+        version = "1.0.27";
         edition = "2021";
-        sha256 = "0vdra0766jcc2czzqwhql41kkfyajdnai1pbkjxbq8vr7mvqyvi1";
+        sha256 = "1hv5sf0j7b65gz2g57c3wp0fzr5r3807dywf6fap455lwjs0yi3y";
         libName = "ref_cast";
         authors = [
           "David Tolnay <dtolnay@gmail.com>"
@@ -9398,9 +9401,9 @@ rec {
       };
       "ref-cast-impl" = rec {
         crateName = "ref-cast-impl";
-        version = "1.0.26";
+        version = "1.0.27";
         edition = "2021";
-        sha256 = "0g70ff9an5i97cw9kijgzqrqydz7smcfic2zyydddizfbxl874ic";
+        sha256 = "0fnzgkvddgl9xs3884x5ypi9rd0dgc1p5vd1k4b74lw49ybdiv4j";
         procMacro = true;
         libName = "ref_cast_impl";
         authors = [
@@ -10432,9 +10435,9 @@ rec {
       };
       "rustls-webpki" = rec {
         crateName = "rustls-webpki";
-        version = "0.103.13";
+        version = "0.103.14";
         edition = "2021";
-        sha256 = "0vkm7z9pnxz5qz66p2kmyy2pwx0g4jnsbqk5xzfhs4czcjl2ki31";
+        sha256 = "0njk28gvbqrsfg1b5r35y4f80n37kcjylj72fpc0k0g60n3529q5";
         libName = "webpki";
         dependencies = [
           {
@@ -10464,7 +10467,7 @@ rec {
           "alloc" = [ "ring?/alloc" "pki-types/alloc" ];
           "aws-lc-rs" = [ "dep:aws-lc-rs" "aws-lc-rs/aws-lc-sys" "aws-lc-rs/prebuilt-nasm" ];
           "aws-lc-rs-fips" = [ "dep:aws-lc-rs" "aws-lc-rs/fips" ];
-          "aws-lc-rs-unstable" = [ "aws-lc-rs" "aws-lc-rs/unstable" ];
+          "aws-lc-rs-unstable" = [ "aws-lc-rs" ];
           "default" = [ "std" ];
           "ring" = [ "dep:ring" ];
           "std" = [ "alloc" "pki-types/std" ];
@@ -11759,8 +11762,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_certs";
         authors = [
@@ -12170,13 +12173,13 @@ rec {
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.115.0";
+        version = "0.116.0";
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_operator";
         authors = [
@@ -12356,7 +12359,8 @@ rec {
           "client-feature-gates" = [ "dep:winnow" ];
           "crds" = [ "dep:stackable-versioned" ];
           "default" = [ "crds" ];
-          "full" = [ "client-feature-gates" "crds" "certs" "test-support" "time" "webhook" "kube-ws" ];
+          "full" = [ "client-feature-gates" "crds" "certs" "test-support" "time" "webhook" "kube-ws" "kube-cel" ];
+          "kube-cel" = [ "kube/cel" ];
           "kube-ws" = [ "kube/ws" ];
           "time" = [ "stackable-shared/time" ];
           "webhook" = [ "dep:stackable-webhook" ];
@@ -12370,8 +12374,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -12405,8 +12409,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_shared";
         authors = [
@@ -12486,8 +12490,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_telemetry";
         authors = [
@@ -12596,8 +12600,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_versioned";
         authors = [
@@ -12646,8 +12650,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         procMacro = true;
         libName = "stackable_versioned_macros";
@@ -12714,8 +12718,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_webhook";
         authors = [
@@ -13232,18 +13236,18 @@ rec {
         ];
 
       };
-      "thiserror 2.0.19" = rec {
+      "thiserror 2.0.20" = rec {
         crateName = "thiserror";
-        version = "2.0.19";
+        version = "2.0.20";
         edition = "2021";
-        sha256 = "1ngwxsjsa64v1n7vb90h2b0i3fqk1piwaf0z6fqdacqfhjc3b909";
+        sha256 = "0kxs6p295jffxhzaxpxv1dwaaf5iqlm6sx8h0djp6ancbxgj71pc";
         authors = [
           "David Tolnay <dtolnay@gmail.com>"
         ];
         dependencies = [
           {
             name = "thiserror-impl";
-            packageId = "thiserror-impl 2.0.19";
+            packageId = "thiserror-impl 2.0.20";
           }
         ];
         features = {
@@ -13277,11 +13281,11 @@ rec {
         ];
 
       };
-      "thiserror-impl 2.0.19" = rec {
+      "thiserror-impl 2.0.20" = rec {
         crateName = "thiserror-impl";
-        version = "2.0.19";
+        version = "2.0.20";
         edition = "2021";
-        sha256 = "1ka10pqy1g8zy5al9m8yadg30jp8hx0q80j8awmd8131yw6gxjs3";
+        sha256 = "1bwjc94gi0xn5jz26h1a8bjj1wdkvvr6jifamyc4mp9n28zcs15w";
         procMacro = true;
         libName = "thiserror_impl";
         authors = [
@@ -13430,9 +13434,9 @@ rec {
       };
       "tinystr" = rec {
         crateName = "tinystr";
-        version = "0.8.3";
+        version = "0.8.4";
         edition = "2021";
-        sha256 = "0vfr8x285w6zsqhna0a9jyhylwiafb2kc8pj2qaqaahw48236cn8";
+        sha256 = "0hzncw8rgk4syla79qscfml46jm7ll1zdp7kdacc42cj8n8prqmi";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -14467,7 +14471,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "time";
@@ -15002,9 +15006,9 @@ rec {
       };
       "uuid" = rec {
         crateName = "uuid";
-        version = "1.24.0";
+        version = "1.24.1";
         edition = "2021";
-        sha256 = "0faj5x0zgri8m3i8dv9qgyhiwqwdyhbl2g351cp3iin4ynk26fdz";
+        sha256 = "1n8b7fg7dbx6ws64387l2i0qq900rw9b7qax63acdh37sczw1vrc";
         authors = [
           "Ashley Mannix<ashleymannix@live.com.au>"
           "Dylan DPC<dylan.dpc@gmail.com>"
@@ -15174,9 +15178,9 @@ rec {
       };
       "wasm-bindgen" = rec {
         crateName = "wasm-bindgen";
-        version = "0.2.126";
+        version = "0.2.127";
         edition = "2021";
-        sha256 = "197rma4qg1kb8l4bl7857pgszzval8s1w740g9myyjh92467q1jb";
+        sha256 = "0w6fa1mkbb6qlkffgy4qaz0hdf496zbjkyiyvs4lvmpd8xbr6w0v";
         libName = "wasm_bindgen";
         authors = [
           "The wasm-bindgen Developers"
@@ -15225,9 +15229,9 @@ rec {
       };
       "wasm-bindgen-futures" = rec {
         crateName = "wasm-bindgen-futures";
-        version = "0.4.76";
+        version = "0.4.77";
         edition = "2021";
-        sha256 = "0799v92cpaprapnmpaflc51sdnz362q2fsjdqnwiq8ij1wsg2bf6";
+        sha256 = "0l3r8m335kb2p8yj65kb0biwlypcx3ay4g750hafkl13rkapfxvb";
         libName = "wasm_bindgen_futures";
         authors = [
           "The wasm-bindgen Developers"
@@ -15253,9 +15257,9 @@ rec {
       };
       "wasm-bindgen-macro" = rec {
         crateName = "wasm-bindgen-macro";
-        version = "0.2.126";
+        version = "0.2.127";
         edition = "2021";
-        sha256 = "1cda6wl5zyiy7777cfgrix7fhpaqba55l5zpqj4zig7ng7jyaz0n";
+        sha256 = "1hcvlb6bv771fvgifd367wd0cm4giyar8fq5i4h705vj7y7myxvp";
         procMacro = true;
         libName = "wasm_bindgen_macro";
         authors = [
@@ -15277,9 +15281,9 @@ rec {
       };
       "wasm-bindgen-macro-support" = rec {
         crateName = "wasm-bindgen-macro-support";
-        version = "0.2.126";
+        version = "0.2.127";
         edition = "2021";
-        sha256 = "03iq412frl2py55skwb3ya08xha0cf6q22zr5kqlwbr675w7r6gk";
+        sha256 = "112j4d7dv8y2sk9yy9czrl9fpjx9388ywnn7icdv2bywazw367g1";
         libName = "wasm_bindgen_macro_support";
         authors = [
           "The wasm-bindgen Developers"
@@ -15313,10 +15317,10 @@ rec {
       };
       "wasm-bindgen-shared" = rec {
         crateName = "wasm-bindgen-shared";
-        version = "0.2.126";
+        version = "0.2.127";
         edition = "2021";
         links = "wasm_bindgen";
-        sha256 = "097a3kbjls447s1lwr41l21x5crrh5vq3h6zsxccz7slrjq4q6yw";
+        sha256 = "1gywp6xv8a27fvm3ga9xby93xyic3hc2s626b9z9rw2xqny4vxky";
         libName = "wasm_bindgen_shared";
         authors = [
           "The wasm-bindgen Developers"
@@ -15331,9 +15335,9 @@ rec {
       };
       "web-sys" = rec {
         crateName = "web-sys";
-        version = "0.3.103";
+        version = "0.3.104";
         edition = "2021";
-        sha256 = "0hb1zdnrp99p5r5q66jagsddmwha460yv2wklvzrzk0b3jvdq8l6";
+        sha256 = "0c0acbvaqzqf21q5vdff2g74fvb7afi91xjplmclybq4d24k6df4";
         libName = "web_sys";
         authors = [
           "The wasm-bindgen Developers"
@@ -15589,6 +15593,10 @@ rec {
           "MouseEvent" = [ "Event" "UiEvent" ];
           "MouseScrollEvent" = [ "Event" "MouseEvent" "UiEvent" ];
           "MutationEvent" = [ "Event" ];
+          "NavigateEvent" = [ "Event" ];
+          "Navigation" = [ "EventTarget" ];
+          "NavigationCurrentEntryChangeEvent" = [ "Event" ];
+          "NavigationHistoryEntry" = [ "EventTarget" ];
           "NetworkInformation" = [ "EventTarget" ];
           "Node" = [ "EventTarget" ];
           "Notification" = [ "EventTarget" ];
@@ -17712,9 +17720,9 @@ rec {
       };
       "writeable" = rec {
         crateName = "writeable";
-        version = "0.6.3";
+        version = "0.6.4";
         edition = "2021";
-        sha256 = "1i54d13h9bpap2hf13xcry1s4lxh7ap3923g8f3c0grd7c9fbyhz";
+        sha256 = "1p3r4s4wbf3dksfpj3xyrn7id5p0f7r74mj6qx6ngjfd6cm2vn1s";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -18051,9 +18059,9 @@ rec {
       };
       "zerotrie" = rec {
         crateName = "zerotrie";
-        version = "0.2.4";
+        version = "0.2.5";
         edition = "2021";
-        sha256 = "1gr0pkcn3qsr6in6iixqyp0vbzwf2j1jzyvh7yl2yydh3p9m548g";
+        sha256 = "0gss16krjzk22m57dz5hkdjg99ibj6pa41qr68na7w1jpp1nk8jf";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -18091,9 +18099,9 @@ rec {
       };
       "zerovec" = rec {
         crateName = "zerovec";
-        version = "0.11.6";
+        version = "0.11.7";
         edition = "2021";
-        sha256 = "0fdjsy6b31q9i0d73sl7xjd12xadbwi45lkpfgqnmasrqg5i3ych";
+        sha256 = "1n4n109wgbbin5hljq6gmbnqqg74yp9igzf40gbw2rkdjyswddcl";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -18137,9 +18145,9 @@ rec {
       };
       "zerovec-derive" = rec {
         crateName = "zerovec-derive";
-        version = "0.11.3";
+        version = "0.11.5";
         edition = "2021";
-        sha256 = "0m85qj92mmfvhjra6ziqky5b1p4kcmp5069k7kfadp5hr8jw8pb2";
+        sha256 = "1a8pz516ddcgxvxq3j1xgprac5wnprlrbyzsgzarj0423la2l8cz";
         procMacro = true;
         libName = "zerovec_derive";
         authors = [
@@ -18156,7 +18164,7 @@ rec {
           }
           {
             name = "syn";
-            packageId = "syn 2.0.119";
+            packageId = "syn 3.0.3";
             features = [ "extra-traits" ];
           }
         ];

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 repository = "https://github.com/stackabletech/opa-operator"
 
 [workspace.dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.115.0", features = ["webhook"] }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.116.0", features = ["webhook"] }
 krb5 = { git = "https://github.com/stackabletech/krb5-rs.git", tag = "v0.1.0" }
 
 anyhow = "1.0"

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,13 +1,13 @@
 {
   "git+https://github.com/stackabletech/krb5-rs.git?tag=v0.1.0#krb5-sys@0.1.0": "148zr0q04163hpirkrff5q7cbxqgwzzxh0091zr4g23x7l64jh39",
   "git+https://github.com/stackabletech/krb5-rs.git?tag=v0.1.0#krb5@0.1.0": "148zr0q04163hpirkrff5q7cbxqgwzzxh0091zr4g23x7l64jh39",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#k8s-version@0.1.3": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-certs@0.4.1": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-operator-derive@0.3.1": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-operator@0.115.0": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-shared@0.1.2": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-telemetry@0.6.5": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-versioned-macros@0.11.1": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-versioned@0.11.1": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-webhook@0.9.2": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb"
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#k8s-version@0.1.3": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-certs@0.4.1": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-operator-derive@0.3.1": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-operator@0.116.0": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-shared@0.1.2": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-telemetry@0.6.5": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-versioned-macros@0.11.1": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-versioned@0.11.1": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-webhook@0.9.2": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9"
 }

--- a/extra/crds.yaml
+++ b/extra/crds.yaml
@@ -1225,7 +1225,8 @@ spec:
                     default: {}
                     description: |-
                       `envOverrides` configure environment variables to be set in the Pods.
-                      It is a map from strings to strings - environment variables and the value to set.
+                      It is a map from environment variable names to their values. The names are validated to be
+                      valid environment variable names.
                       Read the
                       [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                       for more information and consult the operator specific usage guide to find out about
@@ -1846,7 +1847,8 @@ spec:
                           default: {}
                           description: |-
                             `envOverrides` configure environment variables to be set in the Pods.
-                            It is a map from strings to strings - environment variables and the value to set.
+                            It is a map from environment variable names to their values. The names are validated to be
+                            valid environment variable names.
                             Read the
                             [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                             for more information and consult the operator specific usage guide to find out about
@@ -3155,7 +3157,8 @@ spec:
                     default: {}
                     description: |-
                       `envOverrides` configure environment variables to be set in the Pods.
-                      It is a map from strings to strings - environment variables and the value to set.
+                      It is a map from environment variable names to their values. The names are validated to be
+                      valid environment variable names.
                       Read the
                       [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                       for more information and consult the operator specific usage guide to find out about
@@ -3776,7 +3779,8 @@ spec:
                           default: {}
                           description: |-
                             `envOverrides` configure environment variables to be set in the Pods.
-                            It is a map from strings to strings - environment variables and the value to set.
+                            It is a map from environment variable names to their values. The names are validated to be
+                            valid environment variable names.
                             Read the
                             [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                             for more information and consult the operator specific usage guide to find out about

--- a/rust/operator-binary/src/controller/apply.rs
+++ b/rust/operator-binary/src/controller/apply.rs
@@ -14,9 +14,9 @@ use stackable_operator::{
 };
 use strum::{EnumDiscriminants, IntoStaticStr};
 
-use crate::controller::{
-    Applied, KubernetesResources, Prepared, ValidatedCluster, controller_name, operator_name,
-    product_name,
+use crate::{
+    controller::{Applied, KubernetesResources, Prepared, ValidatedCluster},
+    opa_controller::{CONTROLLER_NAME, OPERATOR_NAME, PRODUCT_NAME},
 };
 
 #[derive(Snafu, Debug, EnumDiscriminants)]
@@ -58,9 +58,9 @@ impl<'a> Applier<'a> {
         object_overrides: &'a ObjectOverrides,
     ) -> Applier<'a> {
         let cluster_resources = cluster_resources_new(
-            &product_name(),
-            &operator_name(),
-            &controller_name(),
+            &PRODUCT_NAME,
+            &OPERATOR_NAME,
+            &CONTROLLER_NAME,
             &cluster.name,
             &cluster.namespace,
             &cluster.uid,

--- a/rust/operator-binary/src/controller/build.rs
+++ b/rust/operator-binary/src/controller/build.rs
@@ -6,22 +6,31 @@ use std::{marker::PhantomData, str::FromStr};
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
     builder::meta::ObjectMetaBuilder,
+    kvp::Labels,
     utils::cluster_info::KubernetesClusterInfo,
-    v2::{builder::meta::ownerreference_from_resource, types::common::Port},
+    v2::{
+        builder::meta::ownerreference_from_resource,
+        kvp::label,
+        types::{common::Port, operator::RoleName},
+    },
 };
 
-use crate::controller::{
-    KubernetesResources, Prepared, RoleGroupName, ValidatedCluster,
-    build::resource::{
-        config_map::build_rolegroup_config_map,
-        daemonset::build_server_rolegroup_daemonset,
-        discovery::build_discovery_config_map,
-        rbac::{build_role_binding, build_service_account},
-        service::{
-            build_rolegroup_headless_service, build_rolegroup_metrics_service,
-            build_server_role_service,
+use crate::{
+    controller::{
+        KubernetesResources, Prepared, RoleGroupName, ValidatedCluster,
+        build::resource::{
+            config_map::build_rolegroup_config_map,
+            daemonset::build_server_rolegroup_daemonset,
+            discovery::build_discovery_config_map,
+            rbac::{build_role_binding, build_service_account},
+            service::{
+                build_rolegroup_headless_service, build_rolegroup_metrics_service,
+                build_server_role_service,
+            },
         },
     },
+    crd::OpaRole,
+    opa_controller::{CONTROLLER_NAME, OPERATOR_NAME, PRODUCT_NAME},
 };
 
 pub mod properties;
@@ -134,8 +143,52 @@ pub(crate) fn object_meta(
         .name_and_namespace(cluster)
         .name(name)
         .ownerreference(ownerreference_from_resource(cluster, None, Some(true)))
-        .with_labels(cluster.recommended_labels(role_group_name));
+        .with_labels(recommended_labels_for_role_group_resources(
+            cluster,
+            &OpaRole::Server,
+            role_group_name,
+        ));
     builder
+}
+
+pub(crate) fn recommended_labels_for_cluster_resources(cluster: &ValidatedCluster) -> Labels {
+    label::recommended_labels_for_cluster_resources(
+        &cluster.name,
+        &PRODUCT_NAME,
+        &cluster.product_version,
+        &OPERATOR_NAME,
+        &CONTROLLER_NAME,
+    )
+}
+
+pub(crate) fn recommended_labels_for_role_group_resources(
+    cluster: &ValidatedCluster,
+    role_name: &RoleName,
+    role_group_name: &RoleGroupName,
+) -> Labels {
+    label::recommended_labels_for_role_group_resources(
+        &cluster.name,
+        &PRODUCT_NAME,
+        &cluster.product_version,
+        &OPERATOR_NAME,
+        &CONTROLLER_NAME,
+        role_name,
+        role_group_name,
+    )
+}
+
+/// Selector labels matching the pods of a role.
+pub(crate) fn role_selector(cluster: &ValidatedCluster, role_name: &RoleName) -> Labels {
+    label::role_selector(&cluster.name, &PRODUCT_NAME, role_name)
+}
+
+/// Selector labels matching the pods of a role group.
+pub(crate) fn role_group_selector(
+    cluster: &ValidatedCluster,
+    role_name: &RoleName,
+    role_group_name: &RoleGroupName,
+) -> Labels {
+    label::role_group_selector(&cluster.name, &PRODUCT_NAME, role_name, role_group_name)
 }
 
 #[cfg(test)]

--- a/rust/operator-binary/src/controller/build.rs
+++ b/rust/operator-binary/src/controller/build.rs
@@ -1,7 +1,7 @@
 //! Build steps that turn the [`ValidatedCluster`](super::ValidatedCluster) into
 //! Kubernetes resource specifications.
 
-use std::{marker::PhantomData, str::FromStr};
+use std::marker::PhantomData;
 
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
@@ -29,7 +29,6 @@ use crate::{
             },
         },
     },
-    crd::OpaRole,
     opa_controller::{CONTROLLER_NAME, OPERATOR_NAME, PRODUCT_NAME},
 };
 
@@ -119,35 +118,22 @@ pub fn build(
 /// The port the bundle-builder sidecar listens on, and which OPA connects to for bundle polling.
 pub(crate) const BUNDLE_BUILDER_PORT: Port = Port(3030);
 
-// Placeholder role-group name for the recommended labels of the role-level `Service`, which is not
-// bound to a single role group. `global` matches the historical `app.kubernetes.io/role-group`
-// value.
-stackable_operator::constant!(pub(crate) PLACEHOLDER_ROLE_LEVEL_ROLE_GROUP: RoleGroupName = "global");
-
-// Placeholder role-group name for the recommended labels of the discovery `ConfigMap`, which is a
-// cluster-level object not bound to a single role group.
-stackable_operator::constant!(pub(crate) PLACEHOLDER_DISCOVERY_ROLE_GROUP: RoleGroupName = "discovery");
-
 /// Returns an [`ObjectMetaBuilder`] pre-filled with the namespace, an owner reference back to
-/// the cluster, and the recommended labels for a resource named `name` in `role_group_name`.
+/// the cluster, and the given recommended `labels` for a resource named `name`.
 ///
 /// Consolidates the metadata chain repeated by the child-resource builders. Call sites that
 /// need extra labels/annotations chain them onto the returned builder before calling `build()`.
 pub(crate) fn object_meta(
     cluster: &ValidatedCluster,
     name: impl Into<String>,
-    role_group_name: &RoleGroupName,
+    labels: Labels,
 ) -> ObjectMetaBuilder {
     let mut builder = ObjectMetaBuilder::new();
     builder
         .name_and_namespace(cluster)
         .name(name)
         .ownerreference(ownerreference_from_resource(cluster, None, Some(true)))
-        .with_labels(recommended_labels_for_role_group_resources(
-            cluster,
-            &OpaRole::Server,
-            role_group_name,
-        ));
+        .with_labels(labels);
     builder
 }
 
@@ -158,6 +144,20 @@ pub(crate) fn recommended_labels_for_cluster_resources(cluster: &ValidatedCluste
         &cluster.product_version,
         &OPERATOR_NAME,
         &CONTROLLER_NAME,
+    )
+}
+
+pub(crate) fn recommended_labels_for_role_resources(
+    cluster: &ValidatedCluster,
+    role_name: &RoleName,
+) -> Labels {
+    label::recommended_labels_for_role_resources(
+        &cluster.name,
+        &PRODUCT_NAME,
+        &cluster.product_version,
+        &OPERATOR_NAME,
+        &CONTROLLER_NAME,
+        role_name,
     )
 }
 

--- a/rust/operator-binary/src/controller/build/resource/config_map.rs
+++ b/rust/operator-binary/src/controller/build/resource/config_map.rs
@@ -7,12 +7,16 @@ use stackable_operator::{
     product_logging::framework::VECTOR_CONFIG_FILE,
 };
 
-use crate::controller::{
-    OpaRoleGroupConfig, RoleGroupName, ValidatedCluster,
-    build::{
-        object_meta,
-        properties::{ConfigFileName, config_json, product_logging, user_info_fetcher},
+use crate::{
+    controller::{
+        OpaRoleGroupConfig, RoleGroupName, ValidatedCluster,
+        build::{
+            object_meta,
+            properties::{ConfigFileName, config_json, product_logging, user_info_fetcher},
+            recommended_labels_for_role_group_resources,
+        },
     },
+    crd::OpaRole,
 };
 
 #[derive(Snafu, Debug)]
@@ -50,7 +54,7 @@ pub fn build_rolegroup_config_map(
             .role_group_resource_names(role_group_name)
             .role_group_config_map()
             .to_string(),
-        role_group_name,
+        recommended_labels_for_role_group_resources(cluster, &OpaRole::Server, role_group_name),
     )
     .build();
 

--- a/rust/operator-binary/src/controller/build/resource/daemonset/mod.rs
+++ b/rust/operator-binary/src/controller/build/resource/daemonset/mod.rs
@@ -19,6 +19,7 @@ use stackable_operator::{
         },
     },
     commons::secret_class::SecretClassVolumeProvisionParts,
+    constant,
     k8s_openapi::{
         DeepMerge,
         api::{
@@ -38,7 +39,7 @@ use stackable_operator::{
     },
     utils::{COMMON_BASH_TRAP_FUNCTIONS, cluster_info::KubernetesClusterInfo},
     v2::{
-        builder::pod::container::{EnvVarSet, new_container_builder},
+        builder::pod::container::{EnvVarName, EnvVarSet, new_container_builder},
         product_logging::framework::{
             STACKABLE_LOG_DIR, ValidatedContainerLogConfigChoice, vector_container,
         },
@@ -66,17 +67,20 @@ pub const BUNDLES_ACTIVE_DIR: &str = "/bundles/active";
 pub const BUNDLES_INCOMING_DIR: &str = "/bundles/incoming";
 pub const BUNDLES_TMP_DIR: &str = "/bundles/tmp";
 
-stackable_operator::constant!(CONFIG_VOLUME_NAME: VolumeName = "config");
+constant!(CONFIG_VOLUME_NAME: VolumeName = "config");
 const CONFIG_DIR: &str = "/stackable/config";
-stackable_operator::constant!(LOG_VOLUME_NAME: VolumeName = "log");
-stackable_operator::constant!(BUNDLES_VOLUME_NAME: VolumeName = "bundles");
+constant!(LOG_VOLUME_NAME: VolumeName = "log");
+constant!(BUNDLES_VOLUME_NAME: VolumeName = "bundles");
 const BUNDLES_DIR: &str = "/bundles";
-stackable_operator::constant!(USER_INFO_FETCHER_CREDENTIALS_VOLUME_NAME: VolumeName = "credentials");
+constant!(USER_INFO_FETCHER_CREDENTIALS_VOLUME_NAME: VolumeName = "credentials");
 const USER_INFO_FETCHER_CREDENTIALS_DIR: &str = "/stackable/credentials";
-stackable_operator::constant!(USER_INFO_FETCHER_KERBEROS_VOLUME_NAME: VolumeName = "kerberos");
+constant!(USER_INFO_FETCHER_KERBEROS_VOLUME_NAME: VolumeName = "kerberos");
 const USER_INFO_FETCHER_KERBEROS_DIR: &str = "/stackable/kerberos";
-stackable_operator::constant!(TLS_VOLUME_NAME: VolumeName = "tls");
+constant!(TLS_VOLUME_NAME: VolumeName = "tls");
 const TLS_STORE_DIR: &str = "/stackable/tls";
+
+constant!(CONTAINERDEBUG_LOG_DIRECTORY: EnvVarName = "CONTAINERDEBUG_LOG_DIRECTORY");
+constant!(WATCH_NAMESPACE: EnvVarName = "WATCH_NAMESPACE");
 
 // HTTP probe configuration shared by the bundle-builder and OPA containers. They differ in the
 // probed path (the bundle-builder exposes `/status`, OPA's HTTP server answers `/`), the port and,
@@ -265,7 +269,7 @@ pub fn build_server_rolegroup_daemonset(
             merged_config,
             bundle_builder_container_name.as_ref(),
         )])
-        .add_env_var_from_field_path("WATCH_NAMESPACE", &FieldPathEnvVar::Namespace)
+        .add_env_var_from_field_path(WATCH_NAMESPACE.as_ref(), &FieldPathEnvVar::Namespace)
         .add_volume_mount(BUNDLES_VOLUME_NAME.as_ref(), BUNDLES_DIR)
         .context(AddVolumeMountSnafu)?
         .add_volume_mount(LOG_VOLUME_NAME.as_ref(), STACKABLE_LOG_DIR)
@@ -288,6 +292,16 @@ pub fn build_server_rolegroup_daemonset(
         &Container::BundleBuilder,
     );
 
+    // All operator-set environment variables of the OPA container, collected into an
+    // `EnvVarSet` so that every name occurs only once.
+    let opa_env_vars = EnvVarSet::new().with_value(
+        &CONTAINERDEBUG_LOG_DIRECTORY,
+        format!("{STACKABLE_LOG_DIR}/containerdebug"),
+    );
+    // Environment variable overrides (highest precedence), merged from role and role group.
+    // They are merged in last so that they override any operator-set environment variable.
+    let opa_env_vars = opa_env_vars.merge(rolegroup_config.env_overrides.clone());
+
     cb_opa
         .image_from_product_image(resolved_product_image)
         .command(bash_entrypoint_command())
@@ -297,11 +311,7 @@ pub fn build_server_rolegroup_daemonset(
             cluster.is_tls_enabled(),
             &rolegroup_config.cli_overrides,
         )])
-        .add_env_vars(rolegroup_config.env_overrides.clone())
-        .add_env_var(
-            "CONTAINERDEBUG_LOG_DIRECTORY",
-            format!("{STACKABLE_LOG_DIR}/containerdebug"),
-        );
+        .add_env_vars(opa_env_vars);
 
     // Add appropriate container port based on TLS configuration
     // If we also add a container port "metrics" pointing to the same port number, we get a
@@ -746,6 +756,19 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_constants() {
+        // Test that dereferencing the constants does not panic.
+        let _ = *CONFIG_VOLUME_NAME;
+        let _ = *LOG_VOLUME_NAME;
+        let _ = *BUNDLES_VOLUME_NAME;
+        let _ = *USER_INFO_FETCHER_CREDENTIALS_VOLUME_NAME;
+        let _ = *USER_INFO_FETCHER_KERBEROS_VOLUME_NAME;
+        let _ = *TLS_VOLUME_NAME;
+        let _ = *CONTAINERDEBUG_LOG_DIRECTORY;
+        let _ = *WATCH_NAMESPACE;
+    }
+
     fn build(cluster: &ValidatedCluster) -> DaemonSet {
         let (role_group_name, role_group) = cluster.role_group_configs[&OpaRole::Server]
             .iter()
@@ -1130,5 +1153,63 @@ mod tests {
             mount_path(&uif_container(&ds), "credentials"),
             "/stackable/credentials"
         );
+    }
+
+    /// The user-supplied `envOverrides` must be merged in after all operator-set environment
+    /// variables, so that they can override any of them. `CONTAINERDEBUG_LOG_DIRECTORY` is used
+    /// as the example here because it is set unconditionally by the operator.
+    #[test]
+    fn env_overrides_override_operator_set_env_vars() {
+        use std::str::FromStr;
+
+        use stackable_operator::v2::builder::pod::container::EnvVarName;
+
+        let cluster = validated_cluster_from_spec(json!({
+            "image": { "productVersion": "1.2.3" },
+            "servers": { "roleGroups": { "default": {} } },
+        }));
+        let (role_group_name, role_group) = cluster.role_group_configs[&OpaRole::Server]
+            .iter()
+            .next()
+            .expect("the default role group should exist");
+        let mut role_group = role_group.clone();
+        role_group.env_overrides = EnvVarSet::new().with_value(
+            &EnvVarName::from_str("CONTAINERDEBUG_LOG_DIRECTORY").expect("valid env var name"),
+            "/custom/log/dir",
+        );
+
+        let ds = build_server_rolegroup_daemonset(
+            &cluster,
+            role_group_name,
+            &role_group,
+            "bundle-builder-image",
+            "user-info-fetcher-image",
+            &cluster_info(),
+        )
+        .expect("the daemonset should build");
+
+        let env = ds
+            .spec
+            .expect("the DaemonSet has a spec")
+            .template
+            .spec
+            .expect("the pod template has a spec")
+            .containers
+            .into_iter()
+            .find(|container| container.name == "opa")
+            .expect("the opa container exists")
+            .env
+            .expect("the opa container has env vars");
+
+        let containerdebug: Vec<_> = env
+            .iter()
+            .filter(|env_var| env_var.name == "CONTAINERDEBUG_LOG_DIRECTORY")
+            .collect();
+        assert_eq!(
+            containerdebug.len(),
+            1,
+            "the override must replace the operator-set value, not duplicate it"
+        );
+        assert_eq!(containerdebug[0].value.as_deref(), Some("/custom/log/dir"));
     }
 }

--- a/rust/operator-binary/src/controller/build/resource/daemonset/mod.rs
+++ b/rust/operator-binary/src/controller/build/resource/daemonset/mod.rs
@@ -12,7 +12,7 @@ use stackable_operator::{
         meta::ObjectMetaBuilder,
         pod::{
             PodBuilder,
-            container::{ContainerBuilder, FieldPathEnvVar},
+            container::FieldPathEnvVar,
             resources::ResourceRequirementsBuilder,
             security::PodSecurityContextBuilder,
             volume::{SecretOperatorVolumeSourceBuilder, VolumeBuilder},
@@ -25,8 +25,8 @@ use stackable_operator::{
         api::{
             apps::v1::{DaemonSet, DaemonSetSpec, DaemonSetUpdateStrategy, RollingUpdateDaemonSet},
             core::v1::{
-                EmptyDirVolumeSource, EnvVarSource, HTTPGetAction, ObjectFieldSelector, Probe,
-                ResourceRequirements,
+                EmptyDirVolumeSource, EnvVar, EnvVarSource, HTTPGetAction, ObjectFieldSelector,
+                Probe, ResourceRequirements,
             },
         },
         apimachinery::pkg::{apis::meta::v1::LabelSelector, util::intstr::IntOrString},
@@ -92,11 +92,11 @@ const READINESS_PROBE_INITIAL_DELAY_SECONDS: i32 = 5;
 const READINESS_PROBE_FAILURE_THRESHOLD: i32 = 5;
 const LIVENESS_PROBE_INITIAL_DELAY_SECONDS: i32 = 30;
 
-const CONSOLE_LOG_LEVEL_ENV: &str = "CONSOLE_LOG_LEVEL";
-const FILE_LOG_LEVEL_ENV: &str = "FILE_LOG_LEVEL";
-const FILE_LOG_DIRECTORY_ENV: &str = "FILE_LOG_DIRECTORY";
-const KUBERNETES_NODE_NAME_ENV: &str = "KUBERNETES_NODE_NAME";
-const KUBERNETES_CLUSTER_DOMAIN_ENV: &str = "KUBERNETES_CLUSTER_DOMAIN";
+constant!(CONSOLE_LOG_LEVEL: EnvVarName = "CONSOLE_LOG_LEVEL");
+constant!(FILE_LOG_LEVEL: EnvVarName = "FILE_LOG_LEVEL");
+constant!(FILE_LOG_DIRECTORY: EnvVarName = "FILE_LOG_DIRECTORY");
+constant!(KUBERNETES_NODE_NAME: EnvVarName = "KUBERNETES_NODE_NAME");
+constant!(KUBERNETES_CLUSTER_DOMAIN: EnvVarName = "KUBERNETES_CLUSTER_DOMAIN");
 
 // logging defaults
 const DEFAULT_FILE_LOG_LEVEL: LogLevel = LogLevel::INFO;
@@ -261,6 +261,16 @@ pub fn build_server_rolegroup_daemonset(
         .context(AddVolumeMountSnafu)?
         .resources(merged_config.resources.to_owned().into());
 
+    // All operator-set environment variables of the bundle-builder container, collected into an
+    // `EnvVarSet` so that every name occurs only once.
+    let bundle_builder_env_vars = EnvVarSet::new()
+        .with_field_path(&WATCH_NAMESPACE, &FieldPathEnvVar::Namespace)
+        .merge(stackable_rust_cli_env_vars(
+            cluster_info,
+            sidecar_container_log_level(merged_config, &Container::BundleBuilder).to_string(),
+            &Container::BundleBuilder,
+        ));
+
     cb_bundle_builder
         .image_from_product_image(resolved_product_image) // inherit the pull policy and pull secrets, and then...
         .image(opa_bundle_builder_image) // ...override the image
@@ -269,7 +279,7 @@ pub fn build_server_rolegroup_daemonset(
             merged_config,
             bundle_builder_container_name.as_ref(),
         )])
-        .add_env_var_from_field_path(WATCH_NAMESPACE.as_ref(), &FieldPathEnvVar::Namespace)
+        .add_env_vars(bundle_builder_env_vars)
         .add_volume_mount(BUNDLES_VOLUME_NAME.as_ref(), BUNDLES_DIR)
         .context(AddVolumeMountSnafu)?
         .add_volume_mount(LOG_VOLUME_NAME.as_ref(), STACKABLE_LOG_DIR)
@@ -285,12 +295,6 @@ pub fn build_server_rolegroup_daemonset(
             IntOrString::Int(build::BUNDLE_BUILDER_PORT.into()),
             None,
         ));
-    add_stackable_rust_cli_env_vars(
-        &mut cb_bundle_builder,
-        cluster_info,
-        sidecar_container_log_level(merged_config, &Container::BundleBuilder).to_string(),
-        &Container::BundleBuilder,
-    );
 
     // All operator-set environment variables of the OPA container, collected into an
     // `EnvVarSet` so that every name occurs only once.
@@ -511,39 +515,41 @@ pub fn build_server_rolegroup_daemonset(
 /// Env variables that are need to run stackable Rust binaries, such as
 /// * opa-bundle-builder
 /// * user-info-fetcher
-fn add_stackable_rust_cli_env_vars(
-    container_builder: &mut ContainerBuilder,
+fn stackable_rust_cli_env_vars(
     cluster_info: &KubernetesClusterInfo,
     log_level: impl Into<String>,
     container: &Container,
-) {
+) -> EnvVarSet {
     let log_level = log_level.into();
-    container_builder
-        .add_env_var(CONSOLE_LOG_LEVEL_ENV, log_level.clone())
-        .add_env_var(FILE_LOG_LEVEL_ENV, log_level)
-        .add_env_var(
-            FILE_LOG_DIRECTORY_ENV,
-            format!("{STACKABLE_LOG_DIR}/{container}",),
+    EnvVarSet::new()
+        .with_value(&CONSOLE_LOG_LEVEL, log_level.clone())
+        .with_value(&FILE_LOG_LEVEL, log_level)
+        .with_value(
+            &FILE_LOG_DIRECTORY,
+            format!("{STACKABLE_LOG_DIR}/{container}"),
         )
-        .add_env_var_from_source(
-            KUBERNETES_NODE_NAME_ENV,
-            EnvVarSource {
+        // `FieldPathEnvVar` has no variant for `spec.nodeName`, so the `EnvVar` is built by hand.
+        .with_env_var(EnvVar {
+            name: KUBERNETES_NODE_NAME.to_string(),
+            value_from: Some(EnvVarSource {
                 field_ref: Some(ObjectFieldSelector {
                     field_path: "spec.nodeName".to_owned(),
                     ..Default::default()
                 }),
                 ..Default::default()
-            },
-        )
+            }),
+            ..Default::default()
+        })
+        .expect("KUBERNETES_NODE_NAME is a valid environment variable name")
         // We set the cluster domain always explicitly, because the product Pods does not have the
         // RBAC permission to get the `nodes/proxy` resource at cluster scope. This is likely
         // because it only has a RoleBinding and no ClusterRoleBinding.
         // By setting the cluster domain explicitly we avoid that the sidecars try to look it up
         // based on some information coming from the node.
-        .add_env_var(
-            KUBERNETES_CLUSTER_DOMAIN_ENV,
+        .with_value(
+            &KUBERNETES_CLUSTER_DOMAIN,
             cluster_info.cluster_domain.to_string(),
-        );
+        )
 }
 
 fn build_opa_start_command(
@@ -767,6 +773,11 @@ mod tests {
         let _ = *TLS_VOLUME_NAME;
         let _ = *CONTAINERDEBUG_LOG_DIRECTORY;
         let _ = *WATCH_NAMESPACE;
+        let _ = *CONSOLE_LOG_LEVEL;
+        let _ = *FILE_LOG_LEVEL;
+        let _ = *FILE_LOG_DIRECTORY;
+        let _ = *KUBERNETES_NODE_NAME;
+        let _ = *KUBERNETES_CLUSTER_DOMAIN;
     }
 
     fn build(cluster: &ValidatedCluster) -> DaemonSet {
@@ -1153,6 +1164,50 @@ mod tests {
             mount_path(&uif_container(&ds), "credentials"),
             "/stackable/credentials"
         );
+    }
+
+    /// The bundle-builder sidecar must carry the Stackable Rust CLI environment variables and
+    /// `WATCH_NAMESPACE`, each exactly once.
+    #[test]
+    fn bundle_builder_has_cli_env_vars_exactly_once() {
+        let ds = build(&validated_cluster_from_spec(json!({
+            "image": { "productVersion": "1.2.3" },
+            "servers": { "roleGroups": { "default": {} } },
+        })));
+
+        let env = ds
+            .spec
+            .expect("the DaemonSet has a spec")
+            .template
+            .spec
+            .expect("the pod template has a spec")
+            .containers
+            .into_iter()
+            .find(|container| container.name == "bundle-builder")
+            .expect("the bundle-builder container exists")
+            .env
+            .expect("the bundle-builder container has env vars");
+
+        for name in [
+            "WATCH_NAMESPACE",
+            "CONSOLE_LOG_LEVEL",
+            "FILE_LOG_LEVEL",
+            "FILE_LOG_DIRECTORY",
+            "KUBERNETES_NODE_NAME",
+            "KUBERNETES_CLUSTER_DOMAIN",
+        ] {
+            assert_eq!(
+                env.iter().filter(|env_var| env_var.name == name).count(),
+                1,
+                "the env var {name} should be set exactly once"
+            );
+        }
+
+        let cluster_domain = env
+            .iter()
+            .find(|env_var| env_var.name == "KUBERNETES_CLUSTER_DOMAIN")
+            .expect("KUBERNETES_CLUSTER_DOMAIN is set");
+        assert_eq!(cluster_domain.value.as_deref(), Some("cluster.local"));
     }
 
     /// The user-supplied `envOverrides` must be merged in after all operator-set environment

--- a/rust/operator-binary/src/controller/build/resource/daemonset/mod.rs
+++ b/rust/operator-binary/src/controller/build/resource/daemonset/mod.rs
@@ -5,6 +5,7 @@ use std::{collections::BTreeMap, str::FromStr};
 
 use indoc::formatdoc;
 use snafu::{ResultExt, Snafu};
+use stackable_opa_operator::crd::OpaRole;
 use stackable_operator::{
     builder::{
         self,
@@ -49,7 +50,11 @@ use super::service::{self, APP_PORT, APP_PORT_NAME};
 use crate::{
     controller::{
         OpaRoleGroupConfig, RoleGroupName, ValidatedCluster, ValidatedOpaConfig,
-        build::{self, resource::daemonset::user_info_fetcher::add_user_info_fetcher_sidecar},
+        build::{
+            self, recommended_labels_for_role_group_resources,
+            resource::daemonset::user_info_fetcher::add_user_info_fetcher_sidecar,
+            role_group_selector,
+        },
     },
     crd::{Container, DEFAULT_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT},
     operations::graceful_shutdown::add_graceful_shutdown_config,
@@ -339,7 +344,11 @@ pub fn build_server_rolegroup_daemonset(
         ));
 
     let pb_metadata = ObjectMetaBuilder::new()
-        .with_labels(cluster.recommended_labels(role_group_name))
+        .with_labels(recommended_labels_for_role_group_resources(
+            cluster,
+            &OpaRole::Server,
+            role_group_name,
+        ))
         .build();
 
     pb.metadata(pb_metadata)
@@ -462,7 +471,9 @@ pub fn build_server_rolegroup_daemonset(
 
     let daemonset_spec = DaemonSetSpec {
         selector: LabelSelector {
-            match_labels: Some(cluster.role_group_selector(role_group_name).into()),
+            match_labels: Some(
+                role_group_selector(cluster, &OpaRole::Server, role_group_name).into(),
+            ),
             ..LabelSelector::default()
         },
         template: pod_template,

--- a/rust/operator-binary/src/controller/build/resource/daemonset/mod.rs
+++ b/rust/operator-binary/src/controller/build/resource/daemonset/mod.rs
@@ -465,7 +465,11 @@ pub fn build_server_rolegroup_daemonset(
             .role_group_resource_names(role_group_name)
             .daemon_set_name()
             .to_string(),
-        role_group_name,
+        build::recommended_labels_for_role_group_resources(
+            cluster,
+            &OpaRole::Server,
+            role_group_name,
+        ),
     )
     .build();
 

--- a/rust/operator-binary/src/controller/build/resource/daemonset/user_info_fetcher.rs
+++ b/rust/operator-binary/src/controller/build/resource/daemonset/user_info_fetcher.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
     builder::{
@@ -10,10 +12,11 @@ use stackable_operator::{
         },
         tls_verification::{TlsClientDetails, TlsClientDetailsError},
     },
+    constant,
     crd::authentication::ldap,
     k8s_openapi::api::core::v1::SecretVolumeSource,
     utils::cluster_info::KubernetesClusterInfo,
-    v2::builder::pod::container::new_container_builder,
+    v2::builder::pod::container::{EnvVarName, new_container_builder},
 };
 
 use crate::{
@@ -31,6 +34,12 @@ use crate::{
     },
     crd::{Container, user_info_fetcher},
 };
+
+constant!(CONFIG: EnvVarName = "CONFIG");
+constant!(CREDENTIALS_DIR: EnvVarName = "CREDENTIALS_DIR");
+constant!(KRB5_CONFIG: EnvVarName = "KRB5_CONFIG");
+constant!(KRB5_CLIENT_KTNAME: EnvVarName = "KRB5_CLIENT_KTNAME");
+constant!(KRB5CCNAME: EnvVarName = "KRB5CCNAME");
 
 #[derive(Snafu, Debug)]
 pub enum Error {
@@ -86,13 +95,13 @@ pub fn add_user_info_fetcher_sidecar(
             .image(user_info_fetcher_image) // ...override the image
             .command(vec!["stackable-opa-user-info-fetcher".to_string()])
             .add_env_var(
-                "CONFIG",
+                CONFIG.as_ref(),
                 format!(
                     "{CONFIG_DIR}/{file}",
                     file = build::properties::ConfigFileName::UserInfoFetcher
                 ),
             )
-            .add_env_var("CREDENTIALS_DIR", USER_INFO_FETCHER_CREDENTIALS_DIR)
+            .add_env_var(CREDENTIALS_DIR.as_ref(), USER_INFO_FETCHER_CREDENTIALS_DIR)
             .add_volume_mount(CONFIG_VOLUME_NAME.as_ref(), CONFIG_DIR)
             .context(AddVolumeMountSnafu)?
             .resources(sidecar_resource_requirements());
@@ -132,14 +141,14 @@ pub fn add_user_info_fetcher_sidecar(
                     )
                     .context(KerberosVolumeMountSnafu)?;
                 cb_user_info_fetcher.add_env_var(
-                    "KRB5_CONFIG",
+                    KRB5_CONFIG.as_ref(),
                     format!("{USER_INFO_FETCHER_KERBEROS_DIR}/krb5.conf"),
                 );
                 cb_user_info_fetcher.add_env_var(
-                    "KRB5_CLIENT_KTNAME",
+                    KRB5_CLIENT_KTNAME.as_ref(),
                     format!("{USER_INFO_FETCHER_KERBEROS_DIR}/keytab"),
                 );
-                cb_user_info_fetcher.add_env_var("KRB5CCNAME", "MEMORY:".to_string());
+                cb_user_info_fetcher.add_env_var(KRB5CCNAME.as_ref(), "MEMORY:".to_string());
                 ad.tls
                     .add_volumes_and_mounts(pb, vec![&mut cb_user_info_fetcher])
                     .context(TlsVolumeAndMountsSnafu)?;
@@ -202,4 +211,19 @@ pub fn add_user_info_fetcher_sidecar(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constants() {
+        // Test that dereferencing the constants does not panic.
+        let _ = *CONFIG;
+        let _ = *CREDENTIALS_DIR;
+        let _ = *KRB5_CONFIG;
+        let _ = *KRB5_CLIENT_KTNAME;
+        let _ = *KRB5CCNAME;
+    }
 }

--- a/rust/operator-binary/src/controller/build/resource/daemonset/user_info_fetcher.rs
+++ b/rust/operator-binary/src/controller/build/resource/daemonset/user_info_fetcher.rs
@@ -16,7 +16,7 @@ use stackable_operator::{
     crd::authentication::ldap,
     k8s_openapi::api::core::v1::SecretVolumeSource,
     utils::cluster_info::KubernetesClusterInfo,
-    v2::builder::pod::container::{EnvVarName, new_container_builder},
+    v2::builder::pod::container::{EnvVarName, EnvVarSet, new_container_builder},
 };
 
 use crate::{
@@ -27,8 +27,9 @@ use crate::{
             resource::daemonset::{
                 CONFIG_DIR, CONFIG_VOLUME_NAME, USER_INFO_FETCHER_CREDENTIALS_DIR,
                 USER_INFO_FETCHER_CREDENTIALS_VOLUME_NAME, USER_INFO_FETCHER_KERBEROS_DIR,
-                USER_INFO_FETCHER_KERBEROS_VOLUME_NAME, add_stackable_rust_cli_env_vars,
-                container_name, sidecar_container_log_level, sidecar_resource_requirements,
+                USER_INFO_FETCHER_KERBEROS_VOLUME_NAME, container_name,
+                sidecar_container_log_level, sidecar_resource_requirements,
+                stackable_rust_cli_env_vars,
             },
         },
     },
@@ -90,27 +91,31 @@ pub fn add_user_info_fetcher_sidecar(
         let user_info_fetcher_container_name = container_name(&Container::UserInfoFetcher);
         let mut cb_user_info_fetcher = new_container_builder(&user_info_fetcher_container_name);
 
-        cb_user_info_fetcher
-            .image_from_product_image(&cluster.image) // inherit the pull policy and pull secrets, and then...
-            .image(user_info_fetcher_image) // ...override the image
-            .command(vec!["stackable-opa-user-info-fetcher".to_string()])
-            .add_env_var(
-                CONFIG.as_ref(),
+        // All operator-set environment variables of the user-info-fetcher container, collected
+        // into an `EnvVarSet` so that every name occurs only once. The backend match below may
+        // extend it before it is added to the container.
+        let mut env_vars = EnvVarSet::new()
+            .with_value(
+                &CONFIG,
                 format!(
                     "{CONFIG_DIR}/{file}",
                     file = build::properties::ConfigFileName::UserInfoFetcher
                 ),
             )
-            .add_env_var(CREDENTIALS_DIR.as_ref(), USER_INFO_FETCHER_CREDENTIALS_DIR)
+            .with_value(&CREDENTIALS_DIR, USER_INFO_FETCHER_CREDENTIALS_DIR)
+            .merge(stackable_rust_cli_env_vars(
+                cluster_info,
+                sidecar_container_log_level(merged_config, &Container::UserInfoFetcher).to_string(),
+                &Container::UserInfoFetcher,
+            ));
+
+        cb_user_info_fetcher
+            .image_from_product_image(&cluster.image) // inherit the pull policy and pull secrets, and then...
+            .image(user_info_fetcher_image) // ...override the image
+            .command(vec!["stackable-opa-user-info-fetcher".to_string()])
             .add_volume_mount(CONFIG_VOLUME_NAME.as_ref(), CONFIG_DIR)
             .context(AddVolumeMountSnafu)?
             .resources(sidecar_resource_requirements());
-        add_stackable_rust_cli_env_vars(
-            &mut cb_user_info_fetcher,
-            cluster_info,
-            sidecar_container_log_level(merged_config, &Container::UserInfoFetcher).to_string(),
-            &Container::UserInfoFetcher,
-        );
 
         match &user_info.backend {
             user_info_fetcher::v1alpha2::Backend::None {} => {}
@@ -140,15 +145,16 @@ pub fn add_user_info_fetcher_sidecar(
                         USER_INFO_FETCHER_KERBEROS_DIR,
                     )
                     .context(KerberosVolumeMountSnafu)?;
-                cb_user_info_fetcher.add_env_var(
-                    KRB5_CONFIG.as_ref(),
-                    format!("{USER_INFO_FETCHER_KERBEROS_DIR}/krb5.conf"),
-                );
-                cb_user_info_fetcher.add_env_var(
-                    KRB5_CLIENT_KTNAME.as_ref(),
-                    format!("{USER_INFO_FETCHER_KERBEROS_DIR}/keytab"),
-                );
-                cb_user_info_fetcher.add_env_var(KRB5CCNAME.as_ref(), "MEMORY:".to_string());
+                env_vars = env_vars
+                    .with_value(
+                        &KRB5_CONFIG,
+                        format!("{USER_INFO_FETCHER_KERBEROS_DIR}/krb5.conf"),
+                    )
+                    .with_value(
+                        &KRB5_CLIENT_KTNAME,
+                        format!("{USER_INFO_FETCHER_KERBEROS_DIR}/keytab"),
+                    )
+                    .with_value(&KRB5CCNAME, "MEMORY:");
                 ad.tls
                     .add_volumes_and_mounts(pb, vec![&mut cb_user_info_fetcher])
                     .context(TlsVolumeAndMountsSnafu)?;
@@ -207,6 +213,7 @@ pub fn add_user_info_fetcher_sidecar(
             }
         }
 
+        cb_user_info_fetcher.add_env_vars(env_vars);
         pb.add_container(cb_user_info_fetcher.build());
     }
 

--- a/rust/operator-binary/src/controller/build/resource/discovery.rs
+++ b/rust/operator-binary/src/controller/build/resource/discovery.rs
@@ -6,9 +6,12 @@ use stackable_operator::{
 };
 
 use super::service::{APP_PORT, APP_TLS_PORT};
-use crate::controller::{
-    ValidatedCluster,
-    build::{PLACEHOLDER_DISCOVERY_ROLE_GROUP, object_meta},
+use crate::{
+    controller::{
+        ValidatedCluster,
+        build::{object_meta, recommended_labels_for_role_resources},
+    },
+    crd::OpaRole,
 };
 
 #[derive(Snafu, Debug)]
@@ -40,12 +43,12 @@ pub fn build_discovery_config_map(
         cluster_domain = cluster_info.cluster_domain,
     );
 
-    // Discovery is a cluster-level object (named after the cluster); `discovery` is used as a
-    // placeholder role-group name for the recommended labels.
+    // The discovery ConfigMap is named after the cluster and exposes the server role, so it
+    // carries the role-level recommended labels (no `app.kubernetes.io/role-group` label).
     let metadata = object_meta(
         cluster,
         cluster.name.to_string(),
-        &PLACEHOLDER_DISCOVERY_ROLE_GROUP,
+        recommended_labels_for_role_resources(cluster, &OpaRole::Server),
     )
     .build();
 

--- a/rust/operator-binary/src/controller/build/resource/rbac.rs
+++ b/rust/operator-binary/src/controller/build/resource/rbac.rs
@@ -1,27 +1,18 @@
 //! Builds the RBAC resources (ServiceAccount + RoleBinding) shared by all role groups.
 
-use std::str::FromStr;
-
 use stackable_operator::{
     k8s_openapi::api::{core::v1::ServiceAccount, rbac::v1::RoleBinding},
-    kvp::Labels,
-    v2::{
-        rbac,
-        types::operator::{RoleGroupName, RoleName},
-    },
+    v2::rbac,
 };
 
-use crate::controller::ValidatedCluster;
-
-stackable_operator::constant!(NONE_ROLE_NAME: RoleName = "none");
-stackable_operator::constant!(NONE_ROLE_GROUP_NAME: RoleGroupName = "none");
+use crate::controller::{ValidatedCluster, build::recommended_labels_for_cluster_resources};
 
 /// Builds the [`ServiceAccount`] that the role-group Pods run under.
 pub fn build_service_account(cluster: &ValidatedCluster) -> ServiceAccount {
     rbac::build_service_account(
         cluster,
         &cluster.cluster_resource_names(),
-        rbac_labels(cluster),
+        recommended_labels_for_cluster_resources(cluster),
     )
 }
 
@@ -31,14 +22,8 @@ pub fn build_role_binding(cluster: &ValidatedCluster) -> RoleBinding {
     rbac::build_role_binding(
         cluster,
         &cluster.cluster_resource_names(),
-        rbac_labels(cluster),
+        recommended_labels_for_cluster_resources(cluster),
     )
-}
-
-/// Both resources are shared by the whole cluster rather than tied to a role or role group, so
-/// the recommended labels carry `none` for both values.
-fn rbac_labels(cluster: &ValidatedCluster) -> Labels {
-    cluster.recommended_labels_for(&NONE_ROLE_NAME, &NONE_ROLE_GROUP_NAME)
 }
 
 #[cfg(test)]
@@ -69,11 +54,9 @@ mod tests {
                 "metadata": {
                     // The RBAC resources are cluster-shared, so role and role group are `none`.
                     "labels": {
-                        "app.kubernetes.io/component": "none",
-                        "app.kubernetes.io/instance": "test-opa",
+                         "app.kubernetes.io/instance": "test-opa",
                         "app.kubernetes.io/managed-by": "opa.stackable.tech_opacluster",
                         "app.kubernetes.io/name": "opa",
-                        "app.kubernetes.io/role-group": "none",
                         "app.kubernetes.io/version": app_version_label("1.2.3"),
                         "stackable.tech/vendor": "Stackable"
                     },
@@ -104,11 +87,9 @@ mod tests {
                 "kind": "RoleBinding",
                 "metadata": {
                     "labels": {
-                        "app.kubernetes.io/component": "none",
                         "app.kubernetes.io/instance": "test-opa",
                         "app.kubernetes.io/managed-by": "opa.stackable.tech_opacluster",
                         "app.kubernetes.io/name": "opa",
-                        "app.kubernetes.io/role-group": "none",
                         "app.kubernetes.io/version": app_version_label("1.2.3"),
                         "stackable.tech/vendor": "Stackable"
                     },

--- a/rust/operator-binary/src/controller/build/resource/rbac.rs
+++ b/rust/operator-binary/src/controller/build/resource/rbac.rs
@@ -52,9 +52,10 @@ mod tests {
                 "apiVersion": "v1",
                 "kind": "ServiceAccount",
                 "metadata": {
-                    // The RBAC resources are cluster-shared, so role and role group are `none`.
+                    // The RBAC resources are cluster-shared, so they carry the cluster-level
+                    // recommended labels (no role or role-group label).
                     "labels": {
-                         "app.kubernetes.io/instance": "test-opa",
+                        "app.kubernetes.io/instance": "test-opa",
                         "app.kubernetes.io/managed-by": "opa.stackable.tech_opacluster",
                         "app.kubernetes.io/name": "opa",
                         "app.kubernetes.io/version": app_version_label("1.2.3"),

--- a/rust/operator-binary/src/controller/build/resource/service.rs
+++ b/rust/operator-binary/src/controller/build/resource/service.rs
@@ -12,7 +12,8 @@ use crate::{
     controller::{
         RoleGroupName, ValidatedCluster,
         build::{
-            PLACEHOLDER_ROLE_LEVEL_ROLE_GROUP, object_meta, role_group_selector, role_selector,
+            object_meta, recommended_labels_for_role_group_resources,
+            recommended_labels_for_role_resources, role_group_selector, role_selector,
         },
     },
     crd::OpaRole,
@@ -27,10 +28,12 @@ pub const METRICS_PORT_NAME: &str = "metrics";
 /// The server-role service is the primary endpoint that should be used by clients that do not perform internal load balancing,
 /// including targets outside of the cluster.
 pub(crate) fn build_server_role_service(cluster: &ValidatedCluster) -> Service {
+    // The role-level Service is not bound to a single role group, so it carries the role-level
+    // recommended labels (no `app.kubernetes.io/role-group` label).
     let metadata = object_meta(
         cluster,
         cluster.server_role_service_name(),
-        &PLACEHOLDER_ROLE_LEVEL_ROLE_GROUP,
+        recommended_labels_for_role_resources(cluster, &OpaRole::Server),
     )
     .build();
 
@@ -68,7 +71,7 @@ pub(crate) fn build_rolegroup_headless_service(
             .role_group_resource_names(role_group_name)
             .headless_service_name()
             .to_string(),
-        role_group_name,
+        recommended_labels_for_role_group_resources(cluster, &OpaRole::Server, role_group_name),
     )
     .build();
 
@@ -126,7 +129,7 @@ pub(crate) fn build_rolegroup_metrics_service(
             .role_group_resource_names(role_group_name)
             .metrics_service_name()
             .to_string(),
-        role_group_name,
+        recommended_labels_for_role_group_resources(cluster, &OpaRole::Server, role_group_name),
     )
     .with_labels(prometheus_labels(&Scraping::Enabled))
     // The metrics are served on the same port as the HTTP/HTTPS traffic, under `/metrics`.

--- a/rust/operator-binary/src/controller/build/resource/service.rs
+++ b/rust/operator-binary/src/controller/build/resource/service.rs
@@ -8,9 +8,14 @@ use stackable_operator::{
     },
 };
 
-use crate::controller::{
-    RoleGroupName, ValidatedCluster,
-    build::{PLACEHOLDER_ROLE_LEVEL_ROLE_GROUP, object_meta},
+use crate::{
+    controller::{
+        RoleGroupName, ValidatedCluster,
+        build::{
+            PLACEHOLDER_ROLE_LEVEL_ROLE_GROUP, object_meta, role_group_selector, role_selector,
+        },
+    },
+    crd::OpaRole,
 };
 
 pub const APP_PORT: Port = Port(8081);
@@ -32,7 +37,7 @@ pub(crate) fn build_server_role_service(cluster: &ValidatedCluster) -> Service {
     let service_spec = ServiceSpec {
         type_: Some(cluster.cluster_config.listener_class.k8s_service_type()),
         ports: Some(data_service_ports(cluster.is_tls_enabled())),
-        selector: Some(cluster.role_selector().into()),
+        selector: Some(role_selector(cluster, &OpaRole::Server).into()),
         // This ensures that products (e.g. Trino) on a node always talk to the OPA pod on the
         // same node, avoiding cross-node latency. The downside is that if the local OPA pod is
         // unavailable, requests fail instead of falling back to another node.
@@ -76,7 +81,7 @@ pub(crate) fn build_rolegroup_headless_service(
     // options there are non-existent (mTLS still opens plain port) or suck (Kerberos).
     let service_spec = headless_cluster_ip_service_spec(
         data_service_ports(cluster.is_tls_enabled()),
-        cluster.role_group_selector(role_group_name).into(),
+        role_group_selector(cluster, &OpaRole::Server, role_group_name).into(),
         true,
     );
 
@@ -135,7 +140,7 @@ pub(crate) fn build_rolegroup_metrics_service(
 
     let service_spec = headless_cluster_ip_service_spec(
         vec![metrics_service_port(tls_enabled)],
-        cluster.role_group_selector(role_group_name).into(),
+        role_group_selector(cluster, &OpaRole::Server, role_group_name).into(),
         false,
     );
 

--- a/rust/operator-binary/src/controller/mod.rs
+++ b/rust/operator-binary/src/controller/mod.rs
@@ -17,28 +17,21 @@ use stackable_operator::{
         rbac::v1::RoleBinding,
     },
     kube::{Resource as KubeResource, api::ObjectMeta},
-    kvp::Labels,
     shared::time::Duration,
     v2::{
         HasName, HasUid, NameIsValidLabelValue,
-        kvp::label::{recommended_labels, role_group_selector, role_selector},
         role_group_utils::ResourceNames,
         role_utils::{self, GenericCommonConfig, RoleGroupConfig},
         types::{
             kubernetes::{NamespaceName, Uid},
-            operator::{
-                ClusterName, ControllerName, OperatorName, ProductName, ProductVersion, RoleName,
-            },
+            operator::{ClusterName, ProductVersion, RoleName},
         },
     },
 };
 
 use crate::{
-    crd::{
-        APP_NAME, OPERATOR_NAME, OpaConfig, OpaConfigOverrides, OpaRole, OpaStorageConfig,
-        user_info_fetcher, v1alpha2,
-    },
-    opa_controller::OPA_CONTROLLER_NAME,
+    crd::{OpaConfig, OpaConfigOverrides, OpaRole, OpaStorageConfig, user_info_fetcher, v1alpha2},
+    opa_controller::PRODUCT_NAME,
 };
 
 pub mod apply;
@@ -103,7 +96,11 @@ impl ValidatedCluster {
 
     /// The name of the role-level load-balanced Kubernetes `Service`, as used in the discovery URL.
     pub fn server_role_service_name(&self) -> String {
-        format!("{name}-{role}", name = self.name, role = OpaRole::Server)
+        format!(
+            "{name}-{role}",
+            name = self.name,
+            role = OpaRole::Server.as_ref(),
+        )
     }
 
     /// Type-safe names for the per-cluster RBAC resources: the ServiceAccount shared by all
@@ -111,7 +108,7 @@ impl ValidatedCluster {
     pub fn cluster_resource_names(&self) -> role_utils::ResourceNames {
         role_utils::ResourceNames {
             cluster_name: self.name.clone(),
-            product_name: product_name(),
+            product_name: PRODUCT_NAME.clone(),
         }
     }
 
@@ -122,72 +119,10 @@ impl ValidatedCluster {
     ) -> ResourceNames {
         ResourceNames {
             cluster_name: self.name.clone(),
-            role_name: OpaRole::Server.into(),
+            role_name: RoleName::clone(&OpaRole::Server),
             role_group_name: role_group_name.clone(),
         }
     }
-
-    pub fn recommended_labels(&self, role_group_name: &RoleGroupName) -> Labels {
-        self.recommended_labels_for(&OpaRole::Server.into(), role_group_name)
-    }
-
-    /// Recommended labels for a resource that is not tied to a concrete role,
-    /// using a free-form role/role-group label value.
-    pub fn recommended_labels_for(
-        &self,
-        role_name: &RoleName,
-        role_group_name: &RoleGroupName,
-    ) -> Labels {
-        self.recommended_labels_with(&self.product_version, role_name, role_group_name)
-    }
-
-    fn recommended_labels_with(
-        &self,
-        product_version: &ProductVersion,
-        role_name: &RoleName,
-        role_group_name: &RoleGroupName,
-    ) -> Labels {
-        recommended_labels(
-            self,
-            &product_name(),
-            product_version,
-            &operator_name(),
-            &controller_name(),
-            role_name,
-            role_group_name,
-        )
-    }
-
-    /// Selector labels matching the pods of a role group.
-    pub fn role_group_selector(&self, role_group_name: &RoleGroupName) -> Labels {
-        role_group_selector(
-            self,
-            &product_name(),
-            &OpaRole::Server.into(),
-            role_group_name,
-        )
-    }
-
-    /// Selector labels matching all pods of the (single) OPA role.
-    pub fn role_selector(&self) -> Labels {
-        role_selector(self, &product_name(), &OpaRole::Server.into())
-    }
-}
-
-/// The product name (`opa`) as a type-safe label value.
-pub(crate) fn product_name() -> ProductName {
-    ProductName::from_str(APP_NAME).expect("'opa' is a valid product name")
-}
-
-/// The operator name as a type-safe label value.
-pub(crate) fn operator_name() -> OperatorName {
-    OperatorName::from_str(OPERATOR_NAME).expect("the operator name is a valid label value")
-}
-
-/// The controller name as a type-safe label value.
-pub(crate) fn controller_name() -> ControllerName {
-    ControllerName::from_str(OPA_CONTROLLER_NAME)
-        .expect("the controller name is a valid label value")
 }
 
 impl HasName for ValidatedCluster {
@@ -290,24 +225,6 @@ impl ValidatedOpaConfig {
             logging,
             affinity: merged.affinity,
             graceful_shutdown_timeout: merged.graceful_shutdown_timeout,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use stackable_operator::v2::types::operator::RoleName;
-    use strum::IntoEnumIterator;
-
-    use crate::crd::OpaRole;
-
-    /// Locks the invariant behind the `expect` in the `From<OpaRole> for RoleName` impls:
-    /// every `OpaRole` variant (present and future) must serialise to a valid `RoleName`.
-    #[test]
-    fn every_opa_role_serialises_to_a_valid_role_name() {
-        for role in OpaRole::iter() {
-            let _: RoleName = (&role).into();
-            let _: RoleName = role.into();
         }
     }
 }

--- a/rust/operator-binary/src/controller/update_status.rs
+++ b/rust/operator-binary/src/controller/update_status.rs
@@ -12,7 +12,7 @@ use strum::{EnumDiscriminants, IntoStaticStr};
 
 use crate::{
     controller::{Applied, KubernetesResources},
-    crd::{OPERATOR_NAME, OpaClusterStatus, v1alpha2},
+    crd::{OPA_OPERATOR_NAME, OpaClusterStatus, v1alpha2},
 };
 
 #[derive(Snafu, Debug, EnumDiscriminants)]
@@ -47,7 +47,7 @@ pub async fn update_status(
     };
 
     client
-        .apply_patch_status(OPERATOR_NAME, opa, &status)
+        .apply_patch_status(OPA_OPERATOR_NAME, opa, &status)
         .await
         .context(ApplyStatusSnafu)?;
 

--- a/rust/operator-binary/src/controller/validate.rs
+++ b/rust/operator-binary/src/controller/validate.rs
@@ -11,15 +11,13 @@ use stackable_operator::{
     cli::OperatorEnvironmentOptions,
     commons::product_image_selection,
     product_logging::spec::Logging,
-    role_utils::RoleGroup,
     v2::{
-        builder::pod::container::{EnvVarName, EnvVarSet},
         controller_utils::{get_cluster_name, get_namespace, get_uid},
         product_logging::framework::{
             ValidatedContainerLogConfigChoice, VectorContainerLogConfig,
             validate_logging_configuration_for_container,
         },
-        role_utils::with_validated_config,
+        role_utils::{RoleGroup, with_validated_config},
         types::{kubernetes::ConfigMapName, operator::RoleGroupName},
     },
 };
@@ -181,17 +179,6 @@ pub fn validate(
                     },
                 )?;
 
-            // `envOverrides` is kept as a `HashMap<String, String>`; lift it into the type-safe
-            // `EnvVarSet` consumed by the build step.
-            let mut env_overrides = EnvVarSet::new();
-            for (name, value) in merged.config.env_overrides {
-                env_overrides = env_overrides.with_value(
-                    &EnvVarName::from_str(&name)
-                        .context(ParseEnvVarNameSnafu { name: name.clone() })?,
-                    value,
-                );
-            }
-
             // Validate the logging configuration up-front (borrows the merged config before it is
             // moved into the `OpaRoleGroupConfig` below).
             let logging = validate_logging(
@@ -213,7 +200,7 @@ pub fn validate(
                     replicas: merged.replicas,
                     config: ValidatedOpaConfig::from_merged(merged.config.config, logging),
                     config_overrides: merged.config.config_overrides,
-                    env_overrides,
+                    env_overrides: merged.config.env_overrides.into(),
                     cli_overrides: merged.config.cli_overrides,
                     pod_overrides: merged.config.pod_overrides,
                     product_specific_common_config: merged.config.product_specific_common_config,

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{ops::Deref, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use stackable_operator::{
@@ -12,17 +12,18 @@ use stackable_operator::{
         },
     },
     config::{fragment::Fragment, merge::Merge},
+    constant,
     deep_merger::ObjectOverrides,
     k8s_openapi::apimachinery::pkg::api::resource::Quantity,
     kube::CustomResource,
     product_logging::{self, spec::Logging},
-    role_utils::{EmptyRoleConfig, Role},
+    role_utils::EmptyRoleConfig,
     schemars::{self, JsonSchema},
     shared::time::Duration,
     status::condition::{ClusterCondition, HasStatusCondition},
     v2::{
         config_overrides::JsonConfigOverrides,
-        role_utils::GenericCommonConfig,
+        role_utils::{GenericCommonConfig, Role},
         types::{
             kubernetes::{ConfigMapName, SecretClassName},
             operator::RoleName,
@@ -30,12 +31,12 @@ use stackable_operator::{
     },
     versioned::versioned,
 };
-use strum::{Display, EnumIter, EnumString};
+use strum::{Display, EnumIter};
 
 pub mod user_info_fetcher;
 
 pub const APP_NAME: &str = "opa";
-pub const OPERATOR_NAME: &str = "opa.stackable.tech";
+pub const OPA_OPERATOR_NAME: &str = "opa.stackable.tech";
 pub const FIELD_MANAGER: &str = "opa-operator";
 
 pub const DEFAULT_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_minutes_unchecked(2);
@@ -238,36 +239,20 @@ pub struct OpaConfig {
     pub graceful_shutdown_timeout: Option<Duration>,
 }
 
-#[derive(
-    EnumIter,
-    Clone,
-    Debug,
-    Hash,
-    Deserialize,
-    Eq,
-    JsonSchema,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    Display,
-    EnumString,
-)]
+constant!(SERVER_ROLE_NAME: RoleName = "server");
+
+#[derive(Clone, Debug, EnumIter, Eq, Ord, PartialOrd, PartialEq)]
 pub enum OpaRole {
-    #[serde(rename = "server")]
-    #[strum(serialize = "server")]
     Server,
 }
 
-impl From<OpaRole> for RoleName {
-    fn from(value: OpaRole) -> Self {
-        RoleName::from_str(&value.to_string()).expect("an OpaRole is a valid role name")
-    }
-}
+impl Deref for OpaRole {
+    type Target = RoleName;
 
-impl From<&OpaRole> for RoleName {
-    fn from(value: &OpaRole) -> Self {
-        RoleName::from_str(&value.to_string()).expect("an OpaRole is a valid role name")
+    fn deref(&self) -> &Self::Target {
+        match self {
+            OpaRole::Server => &SERVER_ROLE_NAME,
+        }
     }
 }
 

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -322,7 +322,13 @@ mod tests {
     use indoc::formatdoc;
     use stackable_operator::versioned::test_utils::RoundtripTestData;
 
-    use super::{v1alpha1, v1alpha2};
+    use super::{SERVER_ROLE_NAME, v1alpha1, v1alpha2};
+
+    #[test]
+    fn test_constants() {
+        // Test that dereferencing the constants does not panic.
+        let _ = *SERVER_ROLE_NAME;
+    }
 
     impl RoundtripTestData for v1alpha1::OpaClusterSpec {
         fn roundtrip_test_data() -> Vec<Self> {

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -31,7 +31,7 @@ use stackable_operator::{
 };
 
 use crate::{
-    crd::{OPERATOR_NAME, OpaCluster, OpaClusterVersion, v1alpha2},
+    crd::{OPA_OPERATOR_NAME, OpaCluster, OpaClusterVersion, v1alpha2},
     opa_controller::OPA_FULL_CONTROLLER_NAME,
     webhooks::conversion::create_webhook_server,
 };
@@ -114,9 +114,11 @@ async fn main() -> anyhow::Result<()> {
                     .run(sigterm_watcher.handle())
                     .map(anyhow::Ok);
 
-            let client =
-                client::initialize_operator(Some(OPERATOR_NAME.to_string()), &common.cluster_info)
-                    .await?;
+            let client = client::initialize_operator(
+                Some(OPA_OPERATOR_NAME.to_string()),
+                &common.cluster_info,
+            )
+            .await?;
 
             let kubernetes_cluster_info = client.kubernetes_cluster_info.clone();
 

--- a/rust/operator-binary/src/opa_controller.rs
+++ b/rust/operator-binary/src/opa_controller.rs
@@ -5,13 +5,14 @@
 //! [`crate::controller`] module tree; this file is kept next to `main.rs` for consistency with
 //! the other Stackable operators.
 
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
 use const_format::concatcp;
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
     cli::OperatorEnvironmentOptions,
     cluster_resources::ClusterResourceApplyStrategy,
+    constant,
     kube::{
         core::{DeserializeGuard, error_boundary},
         runtime::controller::Action,
@@ -19,6 +20,7 @@ use stackable_operator::{
     logging::controller::ReconcilerError,
     shared::time::Duration,
     utils::cluster_info::KubernetesClusterInfo,
+    v2::types::operator::{ControllerName, OperatorName, ProductName},
 };
 use strum::{EnumDiscriminants, IntoStaticStr};
 
@@ -29,11 +31,15 @@ use crate::{
         update_status::{self, update_status},
         validate,
     },
-    crd::{OPERATOR_NAME, v1alpha2},
+    crd::{APP_NAME, OPA_OPERATOR_NAME, v1alpha2},
 };
 
 pub const OPA_CONTROLLER_NAME: &str = "opacluster";
-pub const OPA_FULL_CONTROLLER_NAME: &str = concatcp!(OPA_CONTROLLER_NAME, '.', OPERATOR_NAME);
+pub const OPA_FULL_CONTROLLER_NAME: &str = concatcp!(OPA_CONTROLLER_NAME, '.', OPA_OPERATOR_NAME);
+
+constant!(pub(crate) PRODUCT_NAME: ProductName = APP_NAME);
+constant!(pub(crate) OPERATOR_NAME: OperatorName = OPA_OPERATOR_NAME);
+constant!(pub(crate) CONTROLLER_NAME: ControllerName = OPA_CONTROLLER_NAME);
 
 pub(crate) const CONTAINER_IMAGE_BASE_NAME: &str = "opa";
 

--- a/rust/operator-binary/src/opa_controller.rs
+++ b/rust/operator-binary/src/opa_controller.rs
@@ -136,3 +136,16 @@ pub fn error_policy(
         _ => Action::requeue(*Duration::from_secs(10)),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constants() {
+        // Test that dereferencing the constants does not panic.
+        let _ = *PRODUCT_NAME;
+        let _ = *OPERATOR_NAME;
+        let _ = *CONTROLLER_NAME;
+    }
+}

--- a/tests/templates/kuttl/smoke/12-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/12-assert.yaml.j2
@@ -164,7 +164,6 @@ metadata:
     app.kubernetes.io/instance: test-opa
     app.kubernetes.io/managed-by: opa.stackable.tech_opacluster
     app.kubernetes.io/name: opa
-    app.kubernetes.io/role-group: global
     stackable.tech/vendor: Stackable
   ownerReferences:
     - apiVersion: opa.stackable.tech/v1alpha2
@@ -277,7 +276,6 @@ metadata:
     app.kubernetes.io/instance: test-opa
     app.kubernetes.io/managed-by: opa.stackable.tech_opacluster
     app.kubernetes.io/name: opa
-    app.kubernetes.io/role-group: discovery
     stackable.tech/vendor: Stackable
   ownerReferences:
     - apiVersion: opa.stackable.tech/v1alpha2


### PR DESCRIPTION
## Description

Upgrade to stackable-operator 0.116.0 and apply the changes described in stackabletech/issues#877.

Part of stackabletech/issues#877

```
--- PASS: kuttl (101.29s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_opa-1.16.2_openshift-false_use-tls-false (101.28s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [x] Release note snippet added in parent issue

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
