### PR TITLE
fix: Add missing owns/watches and test early-exit reconcile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file.
   the role-level Service (`<cluster>-server`) and the discovery ConfigMap lose
   `app.kubernetes.io/role-group`, and the RBAC ServiceAccount and RoleBinding lose both labels (previously `none`). Anything selecting on these label values must be adjusted. All resources can be updated in place; no manual
   deletion is required ([#880]).
+- The operator now watches all resources that it creates and early-exits the reconcile action when the
+  cluster is marked for deletion ([#882]).
 
 ### Fixed
 
@@ -36,6 +38,7 @@ All notable changes to this project will be documented in this file.
 [#871]: https://github.com/stackabletech/opa-operator/pull/871
 [#872]: https://github.com/stackabletech/opa-operator/pull/872
 [#880]: https://github.com/stackabletech/opa-operator/pull/880
+[#882]: https://github.com/stackabletech/opa-operator/pull/882
 
 ## [26.7.0] - 2026-07-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,6 +3634,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "snafu 0.9.2",
  "stackable-operator",
  "strum",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -12027,6 +12027,12 @@ rec {
             features = [ "chrono" "git2" ];
           }
         ];
+        devDependencies = [
+          {
+            name = "serde_yaml";
+            packageId = "serde_yaml";
+          }
+        ];
 
       };
       "stackable-opa-regorule-library" = rec {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ rustls-pki-types = "1.15"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
 snafu = "0.9"
 strum = { version = "0.28", features = ["derive"] }
 tar = "0.4"

--- a/deploy/helm/opa-operator/templates/clusterrole-operator.yaml
+++ b/deploy/helm/opa-operator/templates/clusterrole-operator.yaml
@@ -15,13 +15,15 @@ rules:
       - nodes/proxy
     verbs:
       - get
-  # Manage core workload resources created per OpaCluster.
-  # All resources are applied via Server-Side Apply (create + patch) and tracked for
-  # orphan cleanup (list + delete).
+  # Manage core workload resources created per OpaCluster (the ServiceAccount provides
+  # workload pod identity). All resources are applied via Server-Side Apply
+  # (create + patch), tracked for orphan cleanup (list + delete) and watched by the
+  # controller.
   - apiGroups:
       - ""
     resources:
       - configmaps
+      - serviceaccounts
       - services
     verbs:
       - create
@@ -30,20 +32,9 @@ rules:
       - list
       - patch
       - watch
-  # ServiceAccount created per OpaCluster for workload pod identity.
-  # Applied via SSA and tracked for orphan cleanup.
-  - apiGroups:
-      - ""
-    resources:
-      - serviceaccounts
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
   # RoleBinding created per OpaCluster to bind the product ClusterRole to the workload
-  # ServiceAccount. Applied via SSA and tracked for orphan cleanup.
+  # ServiceAccount. Applied via SSA and tracked for orphan cleanup and watched by the
+  # controller.
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -54,6 +45,7 @@ rules:
       - get
       - list
       - patch
+      - watch
   # Required to bind the product ClusterRole to the per-cluster ServiceAccount.
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -29,3 +29,6 @@ tracing.workspace = true
 
 [build-dependencies]
 built.workspace = true
+
+[dev-dependencies]
+serde_yaml.workspace = true

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -13,7 +13,8 @@ use stackable_operator::{
     eos::EndOfSupportChecker,
     k8s_openapi::api::{
         apps::v1::DaemonSet,
-        core::v1::{ConfigMap, Service},
+        core::v1::{ConfigMap, Service, ServiceAccount},
+        rbac::v1::RoleBinding,
     },
     kube::{
         CustomResourceExt as _,
@@ -148,15 +149,23 @@ async fn main() -> anyhow::Result<()> {
 
             let controller = controller
                 .owns(
-                    watch_namespace.get_api::<DeserializeGuard<DaemonSet>>(&client),
+                    watch_namespace.get_api::<ConfigMap>(&client),
                     watcher::Config::default(),
                 )
                 .owns(
-                    watch_namespace.get_api::<DeserializeGuard<ConfigMap>>(&client),
+                    watch_namespace.get_api::<DaemonSet>(&client),
                     watcher::Config::default(),
                 )
                 .owns(
-                    watch_namespace.get_api::<DeserializeGuard<Service>>(&client),
+                    watch_namespace.get_api::<RoleBinding>(&client),
+                    watcher::Config::default(),
+                )
+                .owns(
+                    watch_namespace.get_api::<Service>(&client),
+                    watcher::Config::default(),
+                )
+                .owns(
+                    watch_namespace.get_api::<ServiceAccount>(&client),
                     watcher::Config::default(),
                 )
                 .graceful_shutdown_on(sigterm_watcher.handle())

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -149,23 +149,23 @@ async fn main() -> anyhow::Result<()> {
 
             let controller = controller
                 .owns(
-                    watch_namespace.get_api::<ConfigMap>(&client),
+                    watch_namespace.get_api::<DeserializeGuard<ConfigMap>>(&client),
                     watcher::Config::default(),
                 )
                 .owns(
-                    watch_namespace.get_api::<DaemonSet>(&client),
+                    watch_namespace.get_api::<DeserializeGuard<DaemonSet>>(&client),
                     watcher::Config::default(),
                 )
                 .owns(
-                    watch_namespace.get_api::<RoleBinding>(&client),
+                    watch_namespace.get_api::<DeserializeGuard<RoleBinding>>(&client),
                     watcher::Config::default(),
                 )
                 .owns(
-                    watch_namespace.get_api::<Service>(&client),
+                    watch_namespace.get_api::<DeserializeGuard<Service>>(&client),
                     watcher::Config::default(),
                 )
                 .owns(
-                    watch_namespace.get_api::<ServiceAccount>(&client),
+                    watch_namespace.get_api::<DeserializeGuard<ServiceAccount>>(&client),
                     watcher::Config::default(),
                 )
                 .graceful_shutdown_on(sigterm_watcher.handle())

--- a/rust/operator-binary/src/opa_controller.rs
+++ b/rust/operator-binary/src/opa_controller.rs
@@ -14,6 +14,7 @@ use stackable_operator::{
     cluster_resources::ClusterResourceApplyStrategy,
     constant,
     kube::{
+        Resource,
         core::{DeserializeGuard, error_boundary},
         runtime::controller::Action,
     },
@@ -88,6 +89,11 @@ pub async fn reconcile_opa(
     ctx: Arc<Ctx>,
 ) -> Result<Action> {
     tracing::info!("Starting reconcile");
+
+    if opa.meta().deletion_timestamp.is_some() {
+        return Ok(Action::await_change());
+    }
+
     let opa = opa
         .0
         .as_ref()
@@ -139,6 +145,14 @@ pub fn error_policy(
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
+    use stackable_operator::{
+        client::Client,
+        commons::networking::DomainName,
+        kube::{Client as KubeClient, Config},
+    };
+
     use super::*;
 
     #[test]
@@ -147,5 +161,65 @@ mod tests {
         let _ = *PRODUCT_NAME;
         let _ = *OPERATOR_NAME;
         let _ = *CONTROLLER_NAME;
+    }
+
+    /// The client points at a closed port, so any API call would fail the reconciliation: an `Ok`
+    /// proves that a cluster being deleted returns before the reconciler touches the Kubernetes
+    /// API, and because the spec is invalid, before the [`DeserializeGuard`] is unwrapped.
+    #[test]
+    fn reconcile_exits_early_for_deleted_cluster() {
+        // Building the kube client initialises rustls. kube enables its `ring` backend,
+        // but the direct `rustls` dependency also enables the default `aws-lc-rs`
+        // backend - with two candidates rustls refuses to auto-select one and panics.
+        // Install one explicitly, exactly as main() does.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let opa = serde_yaml::from_str(
+            r#"
+apiVersion: opa.stackable.tech/v1alpha2
+kind: OpaCluster
+metadata:
+  name: opa
+  namespace: default
+  deletionTimestamp: "2026-08-14T12:00:00Z"
+spec: {}
+"#,
+        )
+        .expect("YAML parses; the invalid spec is captured inside the DeserializeGuard");
+
+        let action = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread tokio runtime")
+            .block_on(async {
+                let cluster_info = KubernetesClusterInfo {
+                    cluster_domain: DomainName::from_str("cluster.local")
+                        .expect("valid cluster domain"),
+                };
+                let ctx = Arc::new(Ctx {
+                    client: Client::new(
+                        KubeClient::try_from(Config::new(
+                            "http://127.0.0.1:1".parse().expect("valid static URI"),
+                        ))
+                        .expect("client from static config"),
+                        None,
+                        "default".to_owned(),
+                        cluster_info.clone(),
+                    ),
+                    opa_bundle_builder_image: "opa-bundle-builder".to_owned(),
+                    user_info_fetcher_image: "user-info-fetcher".to_owned(),
+                    cluster_info,
+                    operator_environment: OperatorEnvironmentOptions {
+                        operator_namespace: "stackable-operators".to_owned(),
+                        operator_service_name: "opa-operator".to_owned(),
+                        image_repository: "oci.stackable.tech/sdp".to_owned(),
+                    },
+                });
+
+                reconcile_opa(Arc::new(opa), ctx).await
+            })
+            .expect("a deleted cluster reconciles without any API call");
+
+        assert_eq!(action, Action::await_change());
     }
 }

--- a/tests/templates/kuttl/cluster-operation/50-assert.yaml
+++ b/tests/templates/kuttl/cluster-operation/50-assert.yaml
@@ -1,0 +1,91 @@
+---
+# The recreated DaemonSet must bring the cluster back to ready, and the recreated
+# objects must carry an owner reference back to the OpaCluster so that garbage
+# collection still works for them.
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: recreate-owned-resources
+timeout: 600
+commands:
+  - script: kubectl -n $NAMESPACE wait --for=condition=available opaclusters.opa.stackable.tech/test-opa --timeout 601s
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-opa-server-default
+  ownerReferences:
+    - apiVersion: opa.stackable.tech/v1alpha2
+      controller: true
+      kind: OpaCluster
+      name: test-opa
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-opa-serviceaccount
+  ownerReferences:
+    - apiVersion: opa.stackable.tech/v1alpha2
+      controller: true
+      kind: OpaCluster
+      name: test-opa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-opa-rolebinding
+  ownerReferences:
+    - apiVersion: opa.stackable.tech/v1alpha2
+      controller: true
+      kind: OpaCluster
+      name: test-opa
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-opa
+  ownerReferences:
+    - apiVersion: opa.stackable.tech/v1alpha2
+      controller: true
+      kind: OpaCluster
+      name: test-opa
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-opa-server-default
+  ownerReferences:
+    - apiVersion: opa.stackable.tech/v1alpha2
+      controller: true
+      kind: OpaCluster
+      name: test-opa
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-opa-server
+  ownerReferences:
+    - apiVersion: opa.stackable.tech/v1alpha2
+      controller: true
+      kind: OpaCluster
+      name: test-opa
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-opa-server-default-headless
+  ownerReferences:
+    - apiVersion: opa.stackable.tech/v1alpha2
+      controller: true
+      kind: OpaCluster
+      name: test-opa
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-opa-server-default-metrics
+  ownerReferences:
+    - apiVersion: opa.stackable.tech/v1alpha2
+      controller: true
+      kind: OpaCluster
+      name: test-opa

--- a/tests/templates/kuttl/cluster-operation/50-delete-owned-resources.yaml
+++ b/tests/templates/kuttl/cluster-operation/50-delete-owned-resources.yaml
@@ -1,0 +1,61 @@
+---
+# Every resource the operator applies carries an ownerReference and a `.owns()` watch
+# (main.rs): deleting it must trigger a reconcile of the OpaCluster that re-applies it,
+# proving the `.owns()` routing and the ClusterRole `watch` verbs end to end.
+# `.watches()` registrations can't be tested this way: the operator never recreates
+# what it didn't apply.
+#
+# Resources are discovered by label (ClusterResources::add enforces the labels on
+# everything the operator applies), so new resources and kinds are covered
+# automatically. Labels over-match on derived objects, so each match must also carry
+# a controller ownerReference pointing at the OpaCluster; kinds that can never pass that
+# gate are excluded up front. Recreation is proven by UID change, and a floor guard
+# catches a selector that silently matches nothing.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: delete-owned-resources
+timeout: 300
+commands:
+  - script: |
+      set -eu
+
+      delete_and_await_recreation() {
+        resource=$1
+        old_uid=$(kubectl get -n "$NAMESPACE" "$resource" -o jsonpath='{.metadata.uid}')
+        kubectl delete -n "$NAMESPACE" "$resource" --wait=false
+        # Recreation is a single reconcile away, so this normally succeeds on the
+        # first iteration; 30s is a generous upper bound well below the step timeout.
+        for _ in $(seq 1 30); do
+          new_uid=$(kubectl get -n "$NAMESPACE" "$resource" -o jsonpath='{.metadata.uid}' 2>/dev/null || true)
+          if [ -n "$new_uid" ] && [ "$new_uid" != "$old_uid" ]; then
+            return 0
+          fi
+          sleep 1
+        done
+        echo "$resource was not recreated (old uid: $old_uid, current: '${new_uid:-}')" >&2
+        return 1
+      }
+
+      selector="app.kubernetes.io/instance=test-opa,app.kubernetes.io/managed-by=opa.stackable.tech_opacluster"
+      excluded="^(pods|persistentvolumeclaims|endpoints|events)$|^endpointslices\.|^controllerrevisions\.|^events\."
+
+      deleted=0
+      for kind in $(kubectl api-resources --verbs=list --namespaced -o name | grep -Ev "$excluded" | sort); do
+        for resource in $(kubectl get -n "$NAMESPACE" "$kind" -l "$selector" -o name 2>/dev/null); do
+          owner=$(kubectl get -n "$NAMESPACE" "$resource" -o jsonpath='{.metadata.ownerReferences[?(@.controller==true)].kind}/{.metadata.ownerReferences[?(@.controller==true)].name}' 2>/dev/null || true)
+          if [ "$owner" != "OpaCluster/test-opa" ]; then
+            echo "skipping $resource: controller owner is '${owner:-none}', not the OpaCluster"
+            continue
+          fi
+          delete_and_await_recreation "$resource"
+          deleted=$((deleted + 1))
+        done
+      done
+
+      # Guard against the sweep silently matching nothing (wrong selector, renamed
+      # labels): the fixture is known to produce well over this many owned resources.
+      if [ "$deleted" -lt 6 ]; then
+        echo "only $deleted labelled resources were swept - the label selector is broken" >&2
+        exit 1
+      fi


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/878

This PR ensures that the operator now watches all resources that it creates and early-exits the reconcile action when the cluster is marked for deletion. This is tested at unit-test level, as well as by adding a step to one of the kuttl tests to delete all relevant objects and assert that they are re-created.

```
--- PASS: kuttl (100.17s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster-operation_opa-latest-1.16.2_openshift-false (100.15s)
PASS
```


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [x] Release note snippet added in parent issue

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
