### PR TITLE
Add datahub install helm and kuttl timeouts

### DIFF
--- a/tests/templates/kuttl/data-hub-resource-info/03-install-datahub.yaml.j2
+++ b/tests/templates/kuttl/data-hub-resource-info/03-install-datahub.yaml.j2
@@ -2,11 +2,21 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  # The chart runs a `datahub-system-update` bootstrap job (creates the MySQL schema and
-  # the OpenSearch indices) before GMS starts; 03-assert waits for GMS to become ready.
+  # The chart installs its bootstrap jobs (MySQL schema, Kafka topics, OpenSearch indices,
+  # `datahub-system-update`) as Helm hooks, so `helm install` only returns once all of them
+  # have run; 03-assert then waits for GMS to become ready.
+  #
+  # Two timeouts are needed here:
+  #   * `--timeout` is Helm's wait per individual hook. The default (5m) is not enough for
+  #     the system-update job on a contended cluster.
+  #   * `timeout` is kuttl's budget for the whole command, so it has to cover all hooks
+  #     together. It is kept above Helm's so a stuck hook fails with Helm's error message
+  #     instead of kuttl killing the process.
   - script: >-
       helm install datahub datahub
       --namespace $NAMESPACE
       --version {{ test_scenario['values']['data-hub'] }}
       --repo https://helm.datahubproject.io
       --values 03_datahub-values.yaml
+      --timeout 10m
+    timeout: 1200


### PR DESCRIPTION
## Description

- fix weekly test failure: datahub helm install has no timeout and default kuttl timeout is not sufficient on the runners.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
